### PR TITLE
feat(tsgo): move cache to node_modules/.cache/svelte-check-rs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Rust drop-in replacement for `svelte-check` (**Svelte 5+ only**).
 - `crates/tsgo-runner`: Bridge to `tsgo` for TypeScript type-checking.
 - `crates/svelte-check-rs`: Main CLI and orchestration logic.
 - `test-fixtures/`: Svelte component fixtures for testing.
-- `.svelte-check-rs/`: Per-project cache (transformed files, tsgo incremental build info).
+- `node_modules/.cache/svelte-check-rs/`: Per-project cache (transformed files, tsgo incremental build info).
 
 ## Architecture
 
@@ -29,7 +29,7 @@ Rust drop-in replacement for `svelte-check` (**Svelte 5+ only**).
 - External TypeScript type-checker (Go-based, faster than tsc)
 - Auto-installed to cache dir on first run if not found
 - Communication: JSON over stdin/stdout
-- Incremental builds via `.svelte-check-rs/tsgo.tsbuildinfo`
+- Incremental builds via `node_modules/.cache/svelte-check-rs/tsgo.tsbuildinfo`
 
 **SvelteKit Support**:
 - Detects route files (`+page.svelte`, `+layout.svelte`, etc.) for proper prop types
@@ -168,4 +168,3 @@ gh run watch
 ```
 
 **Important**: Do NOT manually create GitHub releases. Monitor with: `gh run list` or `gh run watch`
-

--- a/crates/svelte-check-rs/src/cli.rs
+++ b/crates/svelte-check-rs/src/cli.rs
@@ -105,7 +105,7 @@ pub struct Args {
     #[arg(long = "emit-source-map")]
     pub emit_source_map: bool,
 
-    /// Show cache statistics (files written/skipped to .svelte-check-rs/)
+    /// Show cache statistics (files written/skipped to node_modules/.cache/svelte-check-rs/)
     #[arg(long = "cache-stats")]
     pub cache_stats: bool,
 }

--- a/crates/svelte-check-rs/tests/integration_issues.rs
+++ b/crates/svelte-check-rs/tests/integration_issues.rs
@@ -50,6 +50,14 @@ fn binary_path() -> PathBuf {
         .join("svelte-check-rs")
 }
 
+/// Path to the svelte-check-rs cache directory for a fixture
+fn cache_root(fixture_path: &std::path::Path) -> PathBuf {
+    fixture_path
+        .join("node_modules")
+        .join(".cache")
+        .join("svelte-check-rs")
+}
+
 /// A diagnostic from the JSON output
 #[derive(Debug, Clone, Deserialize)]
 #[allow(dead_code)]
@@ -87,7 +95,7 @@ static BUNDLER_READY: OnceLock<()> = OnceLock::new();
 fn ensure_fixture_ready(fixture_path: &PathBuf, ready: &'static OnceLock<()>) {
     ready.get_or_init(|| {
         // Clean cache to ensure fresh state
-        let cache_path = fixture_path.join(".svelte-check-rs");
+        let cache_path = cache_root(fixture_path);
         let _ = fs::remove_dir_all(&cache_path);
 
         // Check if node_modules exists
@@ -380,7 +388,7 @@ fn test_tsconfig_exclude_filters_svelte_diagnostics() {
     fs::write(&tsconfig_path, updated_tsconfig).expect("Failed to write updated tsconfig");
 
     // Clean cache to ensure tsconfig changes are picked up
-    let cache_path = fixture_path.join(".svelte-check-rs");
+    let cache_path = cache_root(&fixture_path);
     let _ = fs::remove_dir_all(&cache_path);
 
     let (_exit_code, diagnostics) = run_check_json(&fixture_path, "svelte");
@@ -450,7 +458,7 @@ fn test_tsconfig_exclude_wildcard_patterns() {
     fs::write(&tsconfig_path, updated_tsconfig).expect("Failed to write updated tsconfig");
 
     // Clean cache to ensure tsconfig changes are picked up
-    let cache_path = fixture_path.join(".svelte-check-rs");
+    let cache_path = cache_root(&fixture_path);
     let _ = fs::remove_dir_all(&cache_path);
 
     let (_exit_code, diagnostics) = run_check_json(&fixture_path, "svelte");

--- a/crates/svelte-check-rs/tests/integration_tsconfig.rs
+++ b/crates/svelte-check-rs/tests/integration_tsconfig.rs
@@ -48,6 +48,14 @@ fn binary_path() -> std::path::PathBuf {
         .join("svelte-check-rs")
 }
 
+/// Path to the svelte-check-rs cache directory for a fixture
+fn cache_root(fixture_path: &std::path::Path) -> std::path::PathBuf {
+    fixture_path
+        .join("node_modules")
+        .join(".cache")
+        .join("svelte-check-rs")
+}
+
 /// A diagnostic from the JSON output
 #[derive(Debug, Clone, Deserialize)]
 #[allow(dead_code)]
@@ -90,7 +98,7 @@ fn ensure_fixture_ready(fixture_name: &str, ready: &'static OnceLock<()>) {
         let fixture_path = fixtures_dir().join(fixture_name);
 
         // Clean cache to ensure fresh state
-        let cache_path = fixture_path.join(".svelte-check-rs");
+        let cache_path = cache_root(&fixture_path);
         let _ = std::fs::remove_dir_all(&cache_path);
 
         // Check if node_modules exists

--- a/crates/svelte-transformer/src/module.rs
+++ b/crates/svelte-transformer/src/module.rs
@@ -42,7 +42,7 @@ const MODULE_HELPERS: &str = r#"// Svelte module rune helpers
 declare function __svelte_effect(fn: () => void | (() => void)): void;
 declare function __svelte_effect_pre(fn: () => void | (() => void)): void;
 declare function __svelte_effect_root(fn: (...args: any[]) => any): void;
-type __SvelteLoosen<T> = T extends (...args: any) => any ? T : T extends readonly any[] ? T : T extends object ? T & Record<string, any> : T;
+type __SvelteLoosen<T> = T extends (...args: any) => any ? T : T extends readonly any[] ? T : T extends object ? T & Record<string, unknown> : T;
 
 "#;
 

--- a/crates/svelte-transformer/src/transform.rs
+++ b/crates/svelte-transformer/src/transform.rs
@@ -1153,7 +1153,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_component.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_component.snap
@@ -70,7 +70,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_element.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_element.snap
@@ -63,7 +63,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_inline.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_inline.snap
@@ -65,7 +65,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_source_mapping.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_source_mapping.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;
@@ -141,5 +141,5 @@ export default __SvelteComponent_Test_;
 
 
 === Source Map Mappings (2) ===
-  0: generated 4568..4628 -> original 18..78
-  1: generated 4759..4767 -> original 103..111
+  0: generated 4572..4632 -> original 18..78
+  1: generated 4763..4771 -> original 103..111

--- a/crates/svelte-transformer/tests/snapshots/snapshots__await_components.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__await_components.snap
@@ -69,7 +69,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bindable_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bindable_rune.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__binding_checked.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__binding_checked.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__binding_value.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__binding_value.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__complex_events.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__complex_events.snap
@@ -83,7 +83,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__component_namespace.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__component_namespace.snap
@@ -75,7 +75,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__component_snippets_props.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__component_snippets_props.snap
@@ -81,7 +81,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__conditional_components.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__conditional_components.snap
@@ -73,7 +73,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__counter_complete.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__counter_complete.snap
@@ -74,7 +74,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__derived_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__derived_rune.snap
@@ -60,7 +60,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__each_component_key.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__each_component_key.snap
@@ -75,7 +75,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__effect_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__effect_rune.snap
@@ -66,7 +66,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__empty_component.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__empty_component.snap
@@ -54,7 +54,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__event_inline.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__event_inline.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__event_on_directive.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__event_on_directive.snap
@@ -60,7 +60,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__event_reference.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__event_reference.snap
@@ -60,7 +60,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__form_complete.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__form_complete.snap
@@ -73,7 +73,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__generic_multiple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__generic_multiple.snap
@@ -96,7 +96,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__generic_placeholder_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__generic_placeholder_rune.snap
@@ -59,7 +59,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__generic_simple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__generic_simple.snap
@@ -65,7 +65,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__host_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__host_rune.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__inspect_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__inspect_rune.snap
@@ -59,7 +59,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__javascript_component.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__javascript_component.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__layout_children.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__layout_children.snap
@@ -65,7 +65,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__module_script.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__module_script.snap
@@ -65,7 +65,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_components_deep.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_components_deep.snap
@@ -68,7 +68,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_expressions.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_expressions.snap
@@ -62,7 +62,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__only_template.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__only_template.snap
@@ -54,7 +54,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_comment_before.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_comment_before.snap
@@ -61,7 +61,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_generic.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_generic.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_rest.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_rest.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_rest_loosened_annotation.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_rest_loosened_annotation.snap
@@ -60,7 +60,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_rune.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_type_annotation.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_type_annotation.snap
@@ -59,7 +59,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_store_typeof.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_store_typeof.snap
@@ -63,7 +63,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__special_chars.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__special_chars.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__spread_rest_props.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__spread_rest_props.snap
@@ -65,7 +65,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__state_raw_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__state_raw_rune.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__state_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__state_rune.snap
@@ -60,7 +60,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__store_in_script_function.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__store_in_script_function.snap
@@ -63,7 +63,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_css_custom_property.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_css_custom_property.snap
@@ -62,7 +62,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;
@@ -151,12 +151,12 @@ export default __SvelteComponent_Test_;
 
 
 === Source Map Mappings (9) ===
-  0: generated 4568..4590 -> original 18..40
-  1: generated 4590..4591 -> original 40..49
-  2: generated 4591..4609 -> original 49..67
-  3: generated 4609..4615 -> original 67..81
-  4: generated 4615..4617 -> original 81..83
-  5: generated 4748..4791 -> original 124..167
-  6: generated 4837..4838 -> original 180..181
-  7: generated 4852..4857 -> original 214..219
-  8: generated 4861..4866 -> original 238..241
+  0: generated 4572..4594 -> original 18..40
+  1: generated 4594..4595 -> original 40..49
+  2: generated 4595..4613 -> original 49..67
+  3: generated 4613..4619 -> original 67..81
+  4: generated 4619..4621 -> original 81..83
+  5: generated 4752..4795 -> original 124..167
+  6: generated 4841..4842 -> original 180..181
+  7: generated 4856..4861 -> original 214..219
+  8: generated 4865..4870 -> original 238..241

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_expression.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_expression.snap
@@ -59,7 +59,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_important.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_important.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_multiple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_multiple.snap
@@ -66,7 +66,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_shorthand.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_shorthand.snap
@@ -59,7 +59,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_string.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_string.snap
@@ -54,7 +54,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_with_attr.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_with_attr.snap
@@ -58,7 +58,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_await_block.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_await_block.snap
@@ -64,7 +64,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_each_block.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_each_block.snap
@@ -60,7 +60,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_each_else.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_each_else.snap
@@ -62,7 +62,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_expression.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_expression.snap
@@ -59,7 +59,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_if_block.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_if_block.snap
@@ -65,7 +65,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_if_else.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_if_else.snap
@@ -64,7 +64,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_snippet.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_snippet.snap
@@ -66,7 +66,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_basic.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_basic.snap
@@ -60,7 +60,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_deep_member_access.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_deep_member_access.snap
@@ -66,7 +66,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access.snap
@@ -64,7 +64,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access_with_parameter.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access_with_parameter.snap
@@ -65,7 +65,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_multiple_with_member_access.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_multiple_with_member_access.snap
@@ -66,7 +66,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_source_mapping.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_source_mapping.snap
@@ -64,7 +64,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;
@@ -151,5 +151,5 @@ export default __SvelteComponent_Test_;
 
 
 === Source Map Mappings (2) ===
-  0: generated 4568..4688 -> original 18..138
-  1: generated 4867..4879 -> original 159..171
+  0: generated 4572..4692 -> original 18..138
+  1: generated 4871..4883 -> original 159..171

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_with_parameter.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_with_parameter.snap
@@ -61,7 +61,7 @@ type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, 
 type __SvelteLoosen<T> =
   T extends (...args: any) => any ? T :
   T extends readonly any[] ? T :
-  T extends object ? T & Record<string, any> : T;
+  T extends object ? T & Record<string, unknown> : T;
 
 // Helper for $props.<name>() accessors.
 type __SveltePropsAccessor<T> = { [K in keyof T]: () => T[K] } & Record<string, () => any>;

--- a/crates/tsgo-runner/src/lib.rs
+++ b/crates/tsgo-runner/src/lib.rs
@@ -8,6 +8,7 @@
 //! ```ignore
 //! use tsgo_runner::{TsgoRunner, TransformedFiles};
 //! use camino::Utf8PathBuf;
+//! use std::collections::HashMap;
 //!
 //! #[tokio::main]
 //! async fn main() {
@@ -15,6 +16,7 @@
 //!         Utf8PathBuf::from("/usr/local/bin/tsgo"),
 //!         Utf8PathBuf::from("/path/to/project"),
 //!         None,
+//!         HashMap::new(),
 //!         true,
 //!     );
 //!

--- a/docs/index.html
+++ b/docs/index.html
@@ -435,7 +435,7 @@ bun pm trust svelte-check-rs</code>
           <div class="modal-section">
             <h4>Scenarios</h4>
             <ul class="scenario-list">
-              <li><strong>Cold:</strong> Cleared .svelte-kit and .svelte-check-rs caches before each run</li>
+              <li><strong>Cold:</strong> Cleared .svelte-kit and node_modules/.cache/svelte-check-rs caches before each run</li>
               <li><strong>Warm:</strong> Caches preserved, no file changes between runs</li>
               <li><strong>Iterative:</strong> Single file change with dependent consumer updated</li>
             </ul>


### PR DESCRIPTION
## Summary

Fixes #29 - Vite's file watcher was picking up changes in `.svelte-check-rs/` and accidentally serving transformed files instead of original sources.

- Move cache from `.svelte-check-rs/` to `node_modules/.cache/svelte-check-rs/` (industry standard location, automatically ignored by Vite)
- Eliminate ALL symlinks by using TypeScript's `rootDirs` configuration
- Only cache files that need patching (SvelteKit transforms, Promise.all fixes) instead of hard-linking the entire source tree
- Auto-migrate legacy cache directory on first run
- Improve `__SvelteLoosen` type: use `Record<string, unknown>` instead of `any`

## Test plan

- [ ] Run `cargo test` to verify all tests pass
- [ ] Test on a SvelteKit project with Vite dev server running
- [ ] Verify legacy `.svelte-check-rs/` directory is removed on first run
- [ ] Test on Windows (no symlinks needed anymore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)