### PR TITLE
fix(parser,transformer): resolve issues #35, #36, #37, #38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "source-map"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1768,7 +1768,7 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "svelte-check-rs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "camino",
  "clap",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-diagnostics"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-parser"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "insta",
  "logos",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-transformer"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "tsgo-runner"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "blake3",
  "camino",

--- a/crates/svelte-parser/src/ast.rs
+++ b/crates/svelte-parser/src/ast.rs
@@ -416,6 +416,15 @@ pub enum Attribute {
     Shorthand(ShorthandAttribute),
     /// An attach attribute `{@attach expr}`.
     Attach(AttachAttribute),
+    /// A CSS custom property attribute `--custom-prop="value"`.
+    CssCustomProperty {
+        /// The property name (without the -- prefix).
+        name: SmolStr,
+        /// The property value.
+        value: Option<AttributeValue>,
+        /// The span of the entire attribute.
+        span: Span,
+    },
 }
 
 impl Attribute {
@@ -427,6 +436,7 @@ impl Attribute {
             Attribute::Directive(a) => a.span,
             Attribute::Shorthand(a) => a.span,
             Attribute::Attach(a) => a.span,
+            Attribute::CssCustomProperty { span, .. } => *span,
         }
     }
 }

--- a/crates/tsgo-runner/src/runner.rs
+++ b/crates/tsgo-runner/src/runner.rs
@@ -1120,8 +1120,9 @@ impl TsgoRunner {
             excludes.retain(|path| !path.starts_with(&kit_prefix));
         }
 
-        excludes.push(format!("{}/**/*.svelte.ts", self.project_root));
-        excludes.push(format!("{}/**/*.svelte.js", self.project_root));
+        let clean_project_root = clean_path(&self.project_root);
+        excludes.push(format!("{}/**/*.svelte.ts", clean_project_root));
+        excludes.push(format!("{}/**/*.svelte.js", clean_project_root));
         for source in options.patched_sources {
             excludes.push(clean_path(source).to_string());
         }

--- a/test-fixtures/projects/svelte-modules/src/lib/Issue35Component.svelte
+++ b/test-fixtures/projects/svelte-modules/src/lib/Issue35Component.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+    // Test issue #35: multiline runes with trailing commas in .svelte components
+    // This verifies that the fix applies to component scripts, not just .svelte.ts modules
+
+    type SortOrder = 'asc' | 'desc' | 'none';
+
+    // Test case 1: Multiline $state with generic type and trailing comma
+    let sortOrder = $state<SortOrder>(
+        'asc',
+    );
+
+    // Test case 2: Multiline $derived with generic type and trailing comma
+    let sortLabel = $derived<string>(
+        sortOrder === 'asc' ? 'Ascending' : sortOrder === 'desc' ? 'Descending' : 'None',
+    );
+
+    // Test case 3: Multiline $derived.by with trailing comma
+    let computedValue = $derived.by<number>(
+        () => {
+            return sortOrder === 'asc' ? 1 : sortOrder === 'desc' ? -1 : 0;
+        },
+    );
+
+    function toggleSort() {
+        if (sortOrder === 'asc') {
+            sortOrder = 'desc';
+        } else if (sortOrder === 'desc') {
+            sortOrder = 'none';
+        } else {
+            sortOrder = 'asc';
+        }
+    }
+</script>
+
+<div>
+    <p>Sort: {sortLabel} (value: {computedValue})</p>
+    <button onclick={toggleSort}>Toggle Sort</button>
+</div>

--- a/test-fixtures/projects/svelte-modules/src/lib/issue-35-multiline-runes.svelte.ts
+++ b/test-fixtures/projects/svelte-modules/src/lib/issue-35-multiline-runes.svelte.ts
@@ -1,0 +1,100 @@
+// This file tests issue #35: multiline $state<T>(value) with trailing commas
+// See: https://github.com/pheuter/svelte-check-rs/issues/35
+//
+// When $state<T>(value) spans multiple lines with trailing commas,
+// the transformation was producing invalid TypeScript like:
+//   eventOrder = (
+//       'status-start-title', as 'status-start-title' | 'start-title'
+//   );
+// instead of:
+//   eventOrder = ('status-start-title' as 'status-start-title' | 'start-title');
+
+type Bar = { id: number; name: string };
+
+// Test case 1: Multiline $state with trailing comma (the main issue)
+export class PlannerStore {
+    eventOrder = $state<'status-start-title' | 'start-title' | 'title' | ((a: Bar, b: Bar) => number)>(
+        'status-start-title',
+    );
+}
+
+// Test case 2: Multiline $state with complex union type and trailing comma
+export class ConfigStore {
+    sortOrder = $state<'asc' | 'desc' | null>(
+        'asc',
+    );
+}
+
+// Test case 3: Multiline $state with function type and trailing comma
+export class CallbackStore {
+    handler = $state<(() => void) | null>(
+        null,
+    );
+}
+
+// Test case 4: Multiline $state with array type and trailing comma
+export class ListStore {
+    items = $state<string[]>(
+        [],
+    );
+}
+
+// Test case 5: Multiline $state with object literal and trailing comma
+export class ObjectStore {
+    config = $state<{ enabled: boolean; value: number }>(
+        { enabled: true, value: 42 },
+    );
+}
+
+// Test case 6: Nested multiline $state patterns
+export class NestedStore {
+    data = $state<{
+        items: Array<{
+            id: number;
+            name: string;
+        }>;
+        count: number;
+    }>(
+        {
+            items: [],
+            count: 0,
+        },
+    );
+}
+
+// Test case 7: Multiline with extra whitespace and trailing comma
+export class WhitespaceStore {
+    value = $state<number>(
+        42   ,
+    );
+}
+
+// Test case 8: Multiline $derived.by with trailing comma (for completeness)
+export class DerivedStore {
+    count = $state(0);
+    doubled = $derived.by<number>(
+        () => this.count * 2,
+    );
+}
+
+// Test case 9: Multiline $state.raw with generic type and trailing comma
+export class RawStore {
+    items = $state.raw<number[]>(
+        [1, 2, 3],
+    );
+}
+
+// Test case 10: Multiline $derived with generic type and trailing comma
+export class DerivedGenericStore {
+    count = $state(0);
+    doubled = $derived<number>(
+        this.count * 2,
+    );
+}
+
+// Test case 11: $state.raw with complex generic type
+export class ComplexRawStore {
+    data = $state.raw<Map<string, { id: number; name: string }>>(
+        new Map(),
+    );
+}

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/test-issues/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/test-issues/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  // Test file for issues #36, #37, #38
+  let value = 'test';
+</script>
+
+<!-- Issue #38: Void elements -->
+<div>
+  line 1<br>
+  line 2<hr>
+  <img src="test.png" alt="test">
+  <input type="text" bind:value>
+</div>
+
+<!-- Issue #37: CSS custom properties - commenting out as it needs a real component -->
+<!-- <MyComponent --primary-color="red" /> -->
+
+<!-- Issue #36: Dot notation - commenting out as it needs threlte -->
+<!-- <T.Mesh rotation.x={Math.PI / 2}></T.Mesh> -->

--- a/test-fixtures/valid/parser/issue-36-dot-notation.svelte
+++ b/test-fixtures/valid/parser/issue-36-dot-notation.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { T } from '@threlte/core'
+</script>
+
+<!-- Issue #36: Dot notation in component names (T.Mesh) -->
+<T.Mesh rotation.x={Math.PI / 2}>
+  <T.BoxGeometry />
+</T.Mesh>
+
+<!-- Additional test cases for dot notation -->
+<T.Group>
+  <T.DirectionalLight position.y={10} />
+</T.Group>

--- a/test-fixtures/valid/parser/issue-37-css-custom-props.svelte
+++ b/test-fixtures/valid/parser/issue-37-css-custom-props.svelte
@@ -1,0 +1,12 @@
+<script>
+  import MyComponent from './MyComponent.svelte'
+</script>
+
+<!-- Issue #37: CSS custom property attributes -->
+<MyComponent --primary-color="red" />
+<MyComponent --primary-color="blue" --secondary-color="green" />
+
+<!-- Additional test cases -->
+<div style:--custom-var="value">
+  Custom styled content
+</div>

--- a/test-fixtures/valid/parser/issue-38-void-elements.svelte
+++ b/test-fixtures/valid/parser/issue-38-void-elements.svelte
@@ -1,0 +1,33 @@
+<script>
+  let text = 'Hello'
+</script>
+
+<!-- Issue #38: HTML void elements should not require closing tags -->
+<div>
+  line 1<br>
+  line 2
+</div>
+
+<!-- More void element test cases -->
+<div>
+  <hr>
+  <img src="test.png" alt="test">
+  <input type="text">
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="style.css">
+  <area shape="rect" coords="0,0,10,10">
+  <base href="/">
+  <col span="2">
+  <embed src="video.mp4">
+  <param name="autoplay" value="true">
+  <source src="audio.mp3" type="audio/mpeg">
+  <track kind="subtitles" src="subs.vtt">
+  <wbr>
+</div>
+
+<!-- Mixed content with void elements -->
+<p>
+  This is some text<br>
+  with a line break<br>
+  and another one.
+</p>


### PR DESCRIPTION
## Summary

This PR addresses four parser and transformer issues:

- **Issue #35**: Multiline runes with trailing commas producing invalid TypeScript
- **Issue #36**: Parser fails on dot notation in attribute names (e.g., `rotation.x={value}`)
- **Issue #37**: Parser fails on CSS custom property attributes (e.g., `--primary-color="red"`)
- **Issue #38**: Parser treats HTML void elements as unclosed tags

### Issue #35: Multiline runes with trailing commas

When using multiline runes with generic type parameters and trailing commas:
```typescript
let mode = $state<'a' | 'b'>(
    'a',
);
```
The transformer was producing invalid TypeScript: `('a', as 'a' | 'b')` instead of `('a' as 'a' | 'b')`.

**Fix**: Added `strip_trailing_comma()` helper that removes trailing commas before the `as` cast for all runes with generics: `$state<T>()`, `$derived<T>()`, `$derived.by<T>()`, `$state.raw<T>()`, and `$bindable()`.

### Issue #36: Dot notation in attribute names

Libraries like threlte use dot notation for attributes:
```svelte
<T.Mesh rotation.x={Math.PI / 2}></T.Mesh>
```

**Fix**: Parser now consumes `.Ident` patterns when parsing attribute names, supporting both simple (`rotation.x`) and deeply nested (`prop.nested.deep`) notation.

### Issue #37: CSS custom property attributes

Svelte supports CSS custom properties as component props:
```svelte
<Component --primary-color="red" --size={dynamicSize} />
```

**Fix**: Added `CssCustomProperty` variant to the `Attribute` enum with proper parsing for `--var-name` syntax and transformer handling for component props.

### Issue #38: HTML void elements

HTML void elements like `<br>`, `<hr>`, `<img>` should not require closing tags:
```svelte
<div>line 1<br>line 2</div>
```

**Fix**: Added `HTML_VOID_ELEMENTS` constant with all 14 HTML5 void elements. Parser now treats these as implicitly self-closing.

## Test plan

- [x] Added unit tests for all four issues in parser.rs
- [x] Added integration tests in integration_issues.rs
- [x] Added test fixtures for each issue
- [x] Verified with `cargo clippy --all-targets -- -D warnings`
- [x] Verified with `cargo fmt`
- [x] All existing tests pass

Closes #35, closes #36, closes #37, closes #38

🤖 Generated with [Claude Code](https://claude.ai/code)