### PR TITLE
fix(parser): handle regex literals in expressions

### DIFF
--- a/crates/svelte-parser/tests/snapshots/snapshots__complex_snippet_const_regex.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__complex_snippet_const_regex.snap
@@ -1,0 +1,169 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+<div class="parent">
+  {#snippet tooltip({ x, y_formatted }: { x: number; y_formatted: string })}
+    {@const [, y_label, y_unit] = y_label_full.match(/^(.+?)\s*\(([^)]+)\)$/) ??
+      [, y_label_full, ``]}
+    {@const segment = Object.entries(x_positions ?? {}).find(([, [start, end]]) =>
+      x >= start && x <= end
+    )}
+    <span>{y_label}: {y_formatted} {y_unit}</span>
+  {/snippet}
+</div>
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            Element(
+                Element {
+                    span: Span {
+                        start: 0,
+                        end: 396,
+                    },
+                    name: "div",
+                    attributes: [
+                        Normal(
+                            NormalAttribute {
+                                span: Span {
+                                    start: 5,
+                                    end: 19,
+                                },
+                                name: "class",
+                                value: Text(
+                                    TextValue {
+                                        span: Span {
+                                            start: 12,
+                                            end: 18,
+                                        },
+                                        value: "parent",
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                    children: [
+                        SnippetBlock(
+                            SnippetBlock {
+                                span: Span {
+                                    start: 23,
+                                    end: 389,
+                                },
+                                name: "tooltip",
+                                parameters_span: Span {
+                                    start: 41,
+                                    end: 95,
+                                },
+                                parameters: "{ x, y_formatted }: { x: number; y_formatted: string }",
+                                body: Fragment {
+                                    nodes: [
+                                        ConstTag(
+                                            ConstTag {
+                                                span: Span {
+                                                    start: 102,
+                                                    end: 206,
+                                                },
+                                                declaration_span: Span {
+                                                    start: 110,
+                                                    end: 205,
+                                                },
+                                                declaration: "[, y_label, y_unit] = y_label_full.match(/^(.+?)\\s*\\(([^)]+)\\)$/) ??\n      [, y_label_full, ``]",
+                                            },
+                                        ),
+                                        ConstTag(
+                                            ConstTag {
+                                                span: Span {
+                                                    start: 211,
+                                                    end: 325,
+                                                },
+                                                declaration_span: Span {
+                                                    start: 219,
+                                                    end: 324,
+                                                },
+                                                declaration: "segment = Object.entries(x_positions ?? {}).find(([, [start, end]]) =>\n      x >= start && x <= end\n    )",
+                                            },
+                                        ),
+                                        Element(
+                                            Element {
+                                                span: Span {
+                                                    start: 330,
+                                                    end: 376,
+                                                },
+                                                name: "span",
+                                                attributes: [],
+                                                children: [
+                                                    Expression(
+                                                        ExpressionTag {
+                                                            span: Span {
+                                                                start: 336,
+                                                                end: 345,
+                                                            },
+                                                            expression_span: Span {
+                                                                start: 337,
+                                                                end: 344,
+                                                            },
+                                                            expression: "y_label",
+                                                        },
+                                                    ),
+                                                    Expression(
+                                                        ExpressionTag {
+                                                            span: Span {
+                                                                start: 347,
+                                                                end: 360,
+                                                            },
+                                                            expression_span: Span {
+                                                                start: 348,
+                                                                end: 359,
+                                                            },
+                                                            expression: "y_formatted",
+                                                        },
+                                                    ),
+                                                    Expression(
+                                                        ExpressionTag {
+                                                            span: Span {
+                                                                start: 361,
+                                                                end: 369,
+                                                            },
+                                                            expression_span: Span {
+                                                                start: 362,
+                                                                end: 368,
+                                                            },
+                                                            expression: "y_unit",
+                                                        },
+                                                    ),
+                                                ],
+                                                self_closing: false,
+                                            },
+                                        ),
+                                    ],
+                                    span: Span {
+                                        start: 97,
+                                        end: 376,
+                                    },
+                                },
+                            },
+                        ),
+                    ],
+                    self_closing: false,
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 396,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 396,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__const_arrow_function_regex.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__const_arrow_function_regex.snap
@@ -1,0 +1,76 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{#if true}{@const check = (s: string): boolean => /test/.test(s)}{check("x")}{/if}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            IfBlock(
+                IfBlock {
+                    span: Span {
+                        start: 0,
+                        end: 82,
+                    },
+                    condition_span: Span {
+                        start: 5,
+                        end: 9,
+                    },
+                    condition: "true",
+                    consequent: Fragment {
+                        nodes: [
+                            ConstTag(
+                                ConstTag {
+                                    span: Span {
+                                        start: 10,
+                                        end: 65,
+                                    },
+                                    declaration_span: Span {
+                                        start: 18,
+                                        end: 64,
+                                    },
+                                    declaration: "check = (s: string): boolean => /test/.test(s)",
+                                },
+                            ),
+                            Expression(
+                                ExpressionTag {
+                                    span: Span {
+                                        start: 65,
+                                        end: 77,
+                                    },
+                                    expression_span: Span {
+                                        start: 66,
+                                        end: 76,
+                                    },
+                                    expression: "check(\"x\")",
+                                },
+                            ),
+                        ],
+                        span: Span {
+                            start: 10,
+                            end: 77,
+                        },
+                    },
+                    alternate: None,
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 82,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 82,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__const_iife_regex.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__const_iife_regex.snap
@@ -1,0 +1,76 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{#if true}{@const result = (() => { return /test/.test(x); })()}{result}{/if}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            IfBlock(
+                IfBlock {
+                    span: Span {
+                        start: 0,
+                        end: 77,
+                    },
+                    condition_span: Span {
+                        start: 5,
+                        end: 9,
+                    },
+                    condition: "true",
+                    consequent: Fragment {
+                        nodes: [
+                            ConstTag(
+                                ConstTag {
+                                    span: Span {
+                                        start: 10,
+                                        end: 64,
+                                    },
+                                    declaration_span: Span {
+                                        start: 18,
+                                        end: 63,
+                                    },
+                                    declaration: "result = (() => { return /test/.test(x); })()",
+                                },
+                            ),
+                            Expression(
+                                ExpressionTag {
+                                    span: Span {
+                                        start: 64,
+                                        end: 72,
+                                    },
+                                    expression_span: Span {
+                                        start: 65,
+                                        end: 71,
+                                    },
+                                    expression: "result",
+                                },
+                            ),
+                        ],
+                        span: Span {
+                            start: 10,
+                            end: 72,
+                        },
+                    },
+                    alternate: None,
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 77,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 77,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__const_with_regex_match.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__const_with_regex_match.snap
@@ -1,0 +1,76 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{#if true}{@const [, label] = value.match(/^(.+?)\s*\(([^)]+)\)$/) ?? [, value, ``]}{label}{/if}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            IfBlock(
+                IfBlock {
+                    span: Span {
+                        start: 0,
+                        end: 96,
+                    },
+                    condition_span: Span {
+                        start: 5,
+                        end: 9,
+                    },
+                    condition: "true",
+                    consequent: Fragment {
+                        nodes: [
+                            ConstTag(
+                                ConstTag {
+                                    span: Span {
+                                        start: 10,
+                                        end: 84,
+                                    },
+                                    declaration_span: Span {
+                                        start: 18,
+                                        end: 83,
+                                    },
+                                    declaration: "[, label] = value.match(/^(.+?)\\s*\\(([^)]+)\\)$/) ?? [, value, ``]",
+                                },
+                            ),
+                            Expression(
+                                ExpressionTag {
+                                    span: Span {
+                                        start: 84,
+                                        end: 91,
+                                    },
+                                    expression_span: Span {
+                                        start: 85,
+                                        end: 90,
+                                    },
+                                    expression: "label",
+                                },
+                            ),
+                        ],
+                        span: Span {
+                            start: 10,
+                            end: 91,
+                        },
+                    },
+                    alternate: None,
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 96,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 96,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__const_with_regex_test.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__const_with_regex_test.snap
@@ -1,0 +1,76 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{#if true}{@const matches = /rgba\([^)]+\)$/.test(color)}{matches}{/if}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            IfBlock(
+                IfBlock {
+                    span: Span {
+                        start: 0,
+                        end: 71,
+                    },
+                    condition_span: Span {
+                        start: 5,
+                        end: 9,
+                    },
+                    condition: "true",
+                    consequent: Fragment {
+                        nodes: [
+                            ConstTag(
+                                ConstTag {
+                                    span: Span {
+                                        start: 10,
+                                        end: 57,
+                                    },
+                                    declaration_span: Span {
+                                        start: 18,
+                                        end: 56,
+                                    },
+                                    declaration: "matches = /rgba\\([^)]+\\)$/.test(color)",
+                                },
+                            ),
+                            Expression(
+                                ExpressionTag {
+                                    span: Span {
+                                        start: 57,
+                                        end: 66,
+                                    },
+                                    expression_span: Span {
+                                        start: 58,
+                                        end: 65,
+                                    },
+                                    expression: "matches",
+                                },
+                            ),
+                        ],
+                        span: Span {
+                            start: 10,
+                            end: 66,
+                        },
+                    },
+                    alternate: None,
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 71,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 71,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__division_not_regex.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__division_not_regex.snap
@@ -1,0 +1,41 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{(a + b) / 2}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            Expression(
+                ExpressionTag {
+                    span: Span {
+                        start: 0,
+                        end: 13,
+                    },
+                    expression_span: Span {
+                        start: 1,
+                        end: 12,
+                    },
+                    expression: "(a + b) / 2",
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 13,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 13,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__multiple_const_with_regex.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__multiple_const_with_regex.snap
@@ -1,0 +1,102 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{#if true}{@const a = /test/.test(x)}{@const b = 2}{a}{b}{/if}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            IfBlock(
+                IfBlock {
+                    span: Span {
+                        start: 0,
+                        end: 62,
+                    },
+                    condition_span: Span {
+                        start: 5,
+                        end: 9,
+                    },
+                    condition: "true",
+                    consequent: Fragment {
+                        nodes: [
+                            ConstTag(
+                                ConstTag {
+                                    span: Span {
+                                        start: 10,
+                                        end: 37,
+                                    },
+                                    declaration_span: Span {
+                                        start: 18,
+                                        end: 36,
+                                    },
+                                    declaration: "a = /test/.test(x)",
+                                },
+                            ),
+                            ConstTag(
+                                ConstTag {
+                                    span: Span {
+                                        start: 37,
+                                        end: 51,
+                                    },
+                                    declaration_span: Span {
+                                        start: 45,
+                                        end: 50,
+                                    },
+                                    declaration: "b = 2",
+                                },
+                            ),
+                            Expression(
+                                ExpressionTag {
+                                    span: Span {
+                                        start: 51,
+                                        end: 54,
+                                    },
+                                    expression_span: Span {
+                                        start: 52,
+                                        end: 53,
+                                    },
+                                    expression: "a",
+                                },
+                            ),
+                            Expression(
+                                ExpressionTag {
+                                    span: Span {
+                                        start: 54,
+                                        end: 57,
+                                    },
+                                    expression_span: Span {
+                                        start: 55,
+                                        end: 56,
+                                    },
+                                    expression: "b",
+                                },
+                            ),
+                        ],
+                        span: Span {
+                            start: 10,
+                            end: 57,
+                        },
+                    },
+                    alternate: None,
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 62,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 62,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__regex_in_template_literal.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__regex_in_template_literal.snap
@@ -1,0 +1,41 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{`result: ${/test/.test(x)}`}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            Expression(
+                ExpressionTag {
+                    span: Span {
+                        start: 0,
+                        end: 29,
+                    },
+                    expression_span: Span {
+                        start: 1,
+                        end: 28,
+                    },
+                    expression: "`result: ${/test/.test(x)}`",
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 29,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 29,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__regex_quantifier_braces.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__regex_quantifier_braces.snap
@@ -1,0 +1,41 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{value.match(/\d{2,4}/)}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            Expression(
+                ExpressionTag {
+                    span: Span {
+                        start: 0,
+                        end: 24,
+                    },
+                    expression_span: Span {
+                        start: 1,
+                        end: 23,
+                    },
+                    expression: "value.match(/\\d{2,4}/)",
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 24,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 24,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__regex_rgba_pattern.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__regex_rgba_pattern.snap
@@ -1,0 +1,41 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{/rgba\([^)]+[,/]\s*0(\.0*)?\s*\)$/.test(color)}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            Expression(
+                ExpressionTag {
+                    span: Span {
+                        start: 0,
+                        end: 48,
+                    },
+                    expression_span: Span {
+                        start: 1,
+                        end: 47,
+                    },
+                    expression: "/rgba\\([^)]+[,/]\\s*0(\\.0*)?\\s*\\)$/.test(color)",
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 48,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 48,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__regex_simple.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__regex_simple.snap
@@ -1,0 +1,41 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{value.match(/test/)}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            Expression(
+                ExpressionTag {
+                    span: Span {
+                        start: 0,
+                        end: 21,
+                    },
+                    expression_span: Span {
+                        start: 1,
+                        end: 20,
+                    },
+                    expression: "value.match(/test/)",
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 21,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 21,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__regex_with_char_class.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__regex_with_char_class.snap
@@ -1,0 +1,41 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{value.match(/[^)]+/)}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            Expression(
+                ExpressionTag {
+                    span: Span {
+                        start: 0,
+                        end: 22,
+                    },
+                    expression_span: Span {
+                        start: 1,
+                        end: 21,
+                    },
+                    expression: "value.match(/[^)]+/)",
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 22,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 22,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__regex_with_parens.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__regex_with_parens.snap
@@ -1,0 +1,41 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{value.match(/^(.+?)\s*\(([^)]+)\)$/)}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            Expression(
+                ExpressionTag {
+                    span: Span {
+                        start: 0,
+                        end: 38,
+                    },
+                    expression_span: Span {
+                        start: 1,
+                        end: 37,
+                    },
+                    expression: "value.match(/^(.+?)\\s*\\(([^)]+)\\)$/)",
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 38,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 38,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__snippet_with_const_regex.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__snippet_with_const_regex.snap
@@ -1,0 +1,92 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+{#snippet tooltip({ x })}
+    {@const match = x.match(/test/)}
+    <span>{match}</span>
+{/snippet}
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            SnippetBlock(
+                SnippetBlock {
+                    span: Span {
+                        start: 0,
+                        end: 98,
+                    },
+                    name: "tooltip",
+                    parameters_span: Span {
+                        start: 18,
+                        end: 23,
+                    },
+                    parameters: "{ x }",
+                    body: Fragment {
+                        nodes: [
+                            ConstTag(
+                                ConstTag {
+                                    span: Span {
+                                        start: 30,
+                                        end: 62,
+                                    },
+                                    declaration_span: Span {
+                                        start: 38,
+                                        end: 61,
+                                    },
+                                    declaration: "match = x.match(/test/)",
+                                },
+                            ),
+                            Element(
+                                Element {
+                                    span: Span {
+                                        start: 67,
+                                        end: 87,
+                                    },
+                                    name: "span",
+                                    attributes: [],
+                                    children: [
+                                        Expression(
+                                            ExpressionTag {
+                                                span: Span {
+                                                    start: 73,
+                                                    end: 80,
+                                                },
+                                                expression_span: Span {
+                                                    start: 74,
+                                                    end: 79,
+                                                },
+                                                expression: "match",
+                                            },
+                                        ),
+                                    ],
+                                    self_closing: false,
+                                },
+                            ),
+                        ],
+                        span: Span {
+                            start: 25,
+                            end: 87,
+                        },
+                    },
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 98,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 98,
+    },
+}

--- a/test-fixtures/valid/issues/issue-46-regex-arrow-iife.svelte
+++ b/test-fixtures/valid/issues/issue-46-regex-arrow-iife.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  // Issue #46: @const with arrow function type annotations and IIFE containing regex
+  let color_value: number | null = $state(0.5);
+  let point_style = $state({ fill: "blue", stroke: "red" });
+
+  function color_scale_fn(value: number): string {
+    return `hsl(${value * 360}, 50%, 50%)`;
+  }
+</script>
+
+{#if color_value !== null}
+  {@const is_transparent_or_none = (color: string | undefined | null): boolean =>
+    !color ||
+    color === "none" ||
+    color === "transparent" ||
+    /rgba\([^)]+[,/]\s*0(\.0*)?\s*\)$/.test(color)}
+  {@const tooltip_bg_color = (() => {
+    const scale_color = color_value != null
+      ? color_scale_fn(color_value)
+      : undefined;
+    if (!is_transparent_or_none(scale_color)) return scale_color;
+    const fill_color = point_style?.fill;
+    if (!is_transparent_or_none(fill_color)) return fill_color;
+    return "rgba(0, 0, 0, 0.7)";
+  })()}
+  <div style="background: {tooltip_bg_color}">Tooltip</div>
+{/if}

--- a/test-fixtures/valid/issues/issue-46-regex-const.svelte
+++ b/test-fixtures/valid/issues/issue-46-regex-const.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  // Issue #46: @const with regex match and complex patterns
+  let y_label_full = $state("Energy (eV)");
+  let color = $state("rgba(255, 0, 0, 0)");
+</script>
+
+{#if y_label_full}
+  {@const [, y_label, y_unit] = y_label_full.match(/^(.+?)\s*\(([^)]+)\)$/) ?? [, y_label_full, ""]}
+  {@const matches = /rgba\([^)]+\)$/.test(color)}
+  <span>{y_label} ({y_unit})</span>
+  {#if matches}<span>RGBA match</span>{/if}
+{/if}

--- a/test-fixtures/valid/issues/issue-46-regex-edge-cases.svelte
+++ b/test-fixtures/valid/issues/issue-46-regex-edge-cases.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  // Issue #46: Regex edge cases - quantifiers, escapes, char classes, etc.
+  let value = $state("test123");
+  let items = $state(["a", "b", "c"]);
+</script>
+
+<!-- Regex with quantifier braces {n,m} -->
+{value.match(/\d{2,4}/)}
+
+<!-- Regex with escape sequences -->
+{value.match(/\n\t\r\s\w/)}
+
+<!-- Regex with character class containing } -->
+{value.match(/[{}]+/)}
+
+<!-- Regex with character class containing ) -->
+{value.match(/[^)]+/)}
+
+<!-- Regex with flags -->
+{value.replace(/test/gi, "REPLACED")}
+
+<!-- Regex with escaped slash -->
+{value.match(/path\/to\/file/)}
+
+<!-- Regex in array -->
+{[/a/, /b/, /c/]}
+
+<!-- Regex in object -->
+{{ pattern: /test/, flags: "gi" }}
+
+<!-- Regex after ternary operator -->
+{true ? /yes/ : /no/}
+
+<!-- Regex after logical operators -->
+{false || /fallback/.test(value)}
+
+<!-- Regex in arrow function filter -->
+{#each items.filter(x => /test/.test(x)) as item}
+  <span>{item}</span>
+{/each}
+
+<!-- Regex in template literal -->
+{`result: ${/test/.test(value)}`}
+
+<!-- Division (should NOT be treated as regex) -->
+{(10 + 5) / 3}
+{value.length / 2}

--- a/test-fixtures/valid/issues/issue-46-regex-simple.svelte
+++ b/test-fixtures/valid/issues/issue-46-regex-simple.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  // Issue #46: Simple regex literal parsing
+  let value = $state("test string");
+</script>
+
+{#if value.match(/test/)}
+  <span>Matches!</span>
+{/if}
+
+{value.replace(/test/g, "replaced")}

--- a/test-fixtures/valid/issues/issue-46-regex-snippet.svelte
+++ b/test-fixtures/valid/issues/issue-46-regex-snippet.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  // Issue #46: Snippet with @const and regex
+  let y_label_full = $state("Energy (eV)");
+  let x_positions: Record<string, [number, number]> = $state({ segment_1: [0, 1] });
+
+  function pretty_sym_point(label: string): string {
+    return label.toUpperCase();
+  }
+</script>
+
+<div class="parent">
+  {#snippet tooltip({ x, y_formatted }: { x: number; y_formatted: string })}
+    {@const [, y_label, y_unit] = y_label_full.match(/^(.+?)\s*\(([^)]+)\)$/) ??
+      [, y_label_full, ""]}
+    {@const segment = Object.entries(x_positions ?? {}).find(([, [start, end]]) =>
+      x >= start && x <= end
+    )}
+    {@const path = segment?.[0].split("_").map((lbl) =>
+      lbl !== "null" ? pretty_sym_point(lbl) : ""
+    ).filter(Boolean).join(" > ") || null}
+    <span>{y_label}: {y_formatted} {y_unit}</span>
+    {#if path}<span>Path: {path}</span>{/if}
+  {/snippet}
+
+  {@render tooltip({ x: 0.5, y_formatted: "1.23" })}
+</div>


### PR DESCRIPTION
## Summary

- Fixes the expression parser to correctly handle regex literals
- Regex patterns containing `()`, `[]`, `{}` no longer affect bracket depth tracking
- `{/regex/}` expressions are now correctly parsed at the template level

Fixes #46

## Test plan

- [x] Unit tests for regex literal parsing (33 new tests)
- [x] Snapshot tests for regex patterns (14 new snapshots)
- [x] Test fixtures for issue #46 patterns (5 new fixtures)
- [x] Integration tests for issue #46 (5 new tests)
- [x] Verified minimal repro from issue now shows 0 errors
- [x] All existing tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.ai/code)