### PR TITLE
fix: recognize role="application" as interactive

### DIFF
--- a/crates/svelte-diagnostics/src/a11y/aria_data.rs
+++ b/crates/svelte-diagnostics/src/a11y/aria_data.rs
@@ -147,7 +147,9 @@ pub fn is_non_interactive_element(tag: &str) -> bool {
 }
 
 /// Roles that are interactive.
+/// Reference: WAI-ARIA 1.2 - https://www.w3.org/TR/wai-aria-1.2/
 pub static INTERACTIVE_ROLES: &[&str] = &[
+    "application", // Declares a region as a web application (interactive widget)
     "button",
     "checkbox",
     "combobox",
@@ -379,6 +381,20 @@ mod tests {
         assert!(is_interactive_element("input"));
         assert!(!is_interactive_element("div"));
         assert!(!is_interactive_element("span"));
+    }
+
+    #[test]
+    fn test_interactive_roles() {
+        // Standard interactive roles
+        assert!(is_interactive_role("button"));
+        assert!(is_interactive_role("link"));
+        assert!(is_interactive_role("textbox"));
+        // application role - declares a region as a web application (interactive widget)
+        // Reference: https://www.w3.org/TR/wai-aria-1.1/#application
+        assert!(is_interactive_role("application"));
+        // Non-interactive roles
+        assert!(!is_interactive_role("document"));
+        assert!(!is_interactive_role("article"));
     }
 
     #[test]

--- a/crates/svelte-diagnostics/src/a11y/mod.rs
+++ b/crates/svelte-diagnostics/src/a11y/mod.rs
@@ -739,6 +739,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_div_with_application_role_and_tabindex() {
+        // Issue #49: A div with role="application" and tabindex should NOT trigger noninteractive-tabindex
+        // role="application" declares a region as a web application (interactive widget)
+        // Reference: https://www.w3.org/TR/wai-aria-1.1/#application
+        let doc =
+            parse(r#"<div role="application" tabindex="0" aria-label="Canvas">content</div>"#)
+                .document;
+        let diagnostics = check(&doc);
+
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| matches!(d.code, DiagnosticCode::A11yNoNoninteractiveTabindex)),
+            "Should NOT trigger noninteractive-tabindex when element has role='application'"
+        );
+    }
+
     // === svelte-ignore pragma tests ===
 
     #[test]


### PR DESCRIPTION
Fixes #49

## Summary

The `role="application"` attribute declares a region as a web application where the author is responsible for managing focus with JavaScript. According to [WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.1/#application), this role indicates an interactive widget, so elements with this role should be allowed to have `tabindex="0"` without triggering the `a11y-no-noninteractive-tabindex` warning.

## Changes

- Added `"application"` to the `INTERACTIVE_ROLES` list in `aria_data.rs`
- Added test cases to verify the fix

## Reproduction

This fixes false positives for patterns like:

```svelte
<div role="application" tabindex="0" aria-label="Interactive canvas">
  <canvas></canvas>
</div>
```

Before this fix, the above would incorrectly produce:
```
Warning: A11y: Non-interactive elements like <div> should not have tabindex (a11y-no-noninteractive-tabindex)
```

## References

- [WAI-ARIA 1.1 - application role](https://www.w3.org/TR/wai-aria-1.1/#application)
- [WAI-ARIA 1.2 - application role](https://www.w3.org/TR/wai-aria-1.2/#application)