### PR TITLE
fix(parser): handle `as` keyword followed by any whitespace in {#each} blocks

### DIFF
--- a/crates/svelte-parser/tests/corpus_test.rs
+++ b/crates/svelte-parser/tests/corpus_test.rs
@@ -146,6 +146,43 @@ fn test_new_test_fixtures() {
     }
 }
 
+/// Regression tests for issues #52 and #54:
+/// - #52: {#each} with destructuring defaults spanning multiple lines
+/// - #54: {#each ... as const as [destructuring with defaults]} on multiple lines
+#[test]
+fn test_each_multiline_as_whitespace() {
+    let fixtures_dir = get_fixtures_dir().join("valid").join("parser");
+
+    let issue_fixtures = [
+        (
+            "issue-52-each-multiline-destructure-default.svelte",
+            "multi-line destructuring with defaults",
+        ),
+        (
+            "issue-54-each-as-const-multiline.svelte",
+            "as const with multi-line destructuring",
+        ),
+    ];
+
+    for (fixture_name, description) in issue_fixtures {
+        let path = fixtures_dir.join(fixture_name);
+        assert!(path.exists(), "Fixture {} should exist", fixture_name);
+
+        let source = fs::read_to_string(&path).expect("Failed to read file");
+        let result = parse(&source);
+
+        assert!(
+            result.errors.is_empty(),
+            "Fixture {} ({}) should parse without errors, but got: {:?}",
+            fixture_name,
+            description,
+            result.errors
+        );
+
+        println!("OK: {} - {}", fixture_name, description);
+    }
+}
+
 #[test]
 fn test_edge_cases() {
     // Test various edge cases that shouldn't panic

--- a/test-fixtures/valid/parser/issue-52-each-multiline-destructure-default.svelte
+++ b/test-fixtures/valid/parser/issue-52-each-multiline-destructure-default.svelte
@@ -1,0 +1,36 @@
+<!-- Issue #52: {#each} with destructuring defaults spanning multiple lines -->
+<script lang="ts">
+  interface DataItem {
+    title: string
+    value?: string | number | null
+    fmt?: string
+  }
+
+  let data: DataItem[] = [
+    { title: `Energy`, value: 1.23, fmt: `.3f` },
+    { title: `Force`, value: 0.01 },
+  ]
+
+  let default_fmt = `.2f`
+</script>
+
+<!-- Multi-line filter + destructuring with default values -->
+<section>
+  {#each data.filter((itm) =>
+      itm.value !== undefined && itm.value !== null
+    ) as
+    { title, value, fmt = default_fmt }
+    (title + value)
+  }
+    <div>{title}: {value}</div>
+  {:else}
+    No data
+  {/each}
+</section>
+
+<!-- Simpler single-line version -->
+<ul>
+  {#each data.filter((d) => d.value != null) as { title, value, fmt = `.2f` } (title)}
+    <li>{title}: {value}</li>
+  {/each}
+</ul>

--- a/test-fixtures/valid/parser/issue-54-each-as-const-multiline.svelte
+++ b/test-fixtures/valid/parser/issue-54-each-as-const-multiline.svelte
@@ -1,0 +1,38 @@
+<!-- Issue #54: {#each ... as const as [destructuring with defaults]} on multiple lines -->
+<script lang="ts">
+  // Test that "as const" with destructuring defaults works on multiple lines
+</script>
+
+<!-- PASSES: as const on same line without defaults -->
+<div id="pass-1">
+  {#each [`pie`, `bubble`] as const as mode (mode)}
+    <span>{mode}</span>
+  {/each}
+</div>
+
+<!-- PASSES: as const with tuple destructuring (no defaults) on same line -->
+<div id="pass-2">
+  {#each [[`a`, 1], [`b`, 2]] as const as [name, val] (name)}
+    <span>{name}: {val}</span>
+  {/each}
+</div>
+
+<!-- Test: as const with destructuring default value on same line -->
+<div id="test-1">
+  {#each [[`a`, 1], [`b`, 2, { x: 1 }]] as const as [name, val, opts = {}] (name)}
+    <span>{name}: {val}</span>
+  {/each}
+</div>
+
+<!-- Test: Multi-line as const with destructuring default -->
+<div id="test-2">
+  {#each [
+    [`Pie`, `pie`],
+    [`Donut`, `pie`, { radius: 40 }],
+  ] as const as
+    [title, mode, props = {}]
+    (title)
+  }
+    <span>{title}: {mode}</span>
+  {/each}
+</div>


### PR DESCRIPTION
## Summary
- Fixes #52: Parser fails on `{#each}` with destructuring defaults spanning multiple lines
- Fixes #54: Parser fails on `{#each ... as const as [destructuring with default values]}`

The parser was searching for ` as ` (space-as-space) to separate the collection expression from the binding pattern in `{#each}` blocks. This failed for multi-line expressions where `as` is followed by a newline instead of a space.

Added `find_as_keyword_in_expr()` that matches ` as` followed by any whitespace character (space, newline, tab, etc.).

## Test plan
- [x] Added test fixture for issue #52 (multi-line destructuring with defaults)
- [x] Added test fixture for issue #54 (as const with multi-line destructuring)
- [x] Verified against original minimal reproduction repo
- [x] All existing tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)