### PR TITLE
refactor(tsgo): replace regex-based Promise.all patch with AST-based transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "source-map"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1768,7 +1768,7 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "svelte-check-rs"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "camino",
  "clap",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-diagnostics"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-parser"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "insta",
  "logos",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-transformer"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -1909,6 +1909,21 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69d63f7f704a2ec937edef90a3eba1f64602eceb60c8deb260c01131f680e8b"
+dependencies = [
+ "new_debug_unreachable",
+ "num-bigint",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_visit",
  "tracing",
 ]
 
@@ -2134,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "tsgo-runner"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "blake3",
  "camino",
@@ -2147,6 +2162,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_parser",
+ "swc_ecma_visit",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rowan = "0.16"
 text-size = "1.1"
 swc_ecma_parser = "32.0"
 swc_ecma_ast = "19.0"
+swc_ecma_visit = "19.0"
 swc_common = { version = "18.0", features = ["sourcemap"] }
 
 # Serialization

--- a/crates/svelte-check-rs/src/orchestrator.rs
+++ b/crates/svelte-check-rs/src/orchestrator.rs
@@ -831,13 +831,11 @@ async fn run_single_check(
                 }
                 if let Some(stats) = &tsgo_stats {
                     eprintln!(
-                        "tsgo write cache: tsx {}/{} stubs {}/{} shim {}/{} tsconfig {}/{}",
+                        "tsgo write cache: tsx {}/{} stubs {}/{} tsconfig {}/{}",
                         stats.cache.tsx_written,
                         stats.cache.tsx_written + stats.cache.tsx_skipped,
                         stats.cache.stub_written,
                         stats.cache.stub_written + stats.cache.stub_skipped,
-                        stats.cache.shim_written,
-                        stats.cache.shim_written + stats.cache.shim_skipped,
                         stats.cache.tsconfig_written,
                         stats.cache.tsconfig_written + stats.cache.tsconfig_skipped
                     );
@@ -876,10 +874,6 @@ async fn run_single_check(
             eprintln!(
                 "Stub files:    {} written, {} skipped",
                 stats.cache.stub_written, stats.cache.stub_skipped
-            );
-            eprintln!(
-                "Shim files:    {} written, {} skipped",
-                stats.cache.shim_written, stats.cache.shim_skipped
             );
             eprintln!(
                 "Kit files:     {} written, {} skipped",
@@ -1141,8 +1135,6 @@ fn timings_json(
                 "kit_skipped": stats.cache.kit_skipped,
                 "patched_written": stats.cache.patched_written,
                 "patched_skipped": stats.cache.patched_skipped,
-                "shim_written": stats.cache.shim_written,
-                "shim_skipped": stats.cache.shim_skipped,
                 "tsconfig_written": stats.cache.tsconfig_written,
                 "tsconfig_skipped": stats.cache.tsconfig_skipped,
                 "source_entries": stats.cache.source_entries,

--- a/crates/tsgo-runner/Cargo.toml
+++ b/crates/tsgo-runner/Cargo.toml
@@ -21,6 +21,7 @@ walkdir.workspace = true
 swc_common.workspace = true
 swc_ecma_parser.workspace = true
 swc_ecma_ast.workspace = true
+swc_ecma_visit.workspace = true
 blake3.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

- Remove `strictFunctionTypes` override - now defers to user's tsconfig setting
- Replace ~500 line regex-based `patch_promise_all_empty_arrays` with ~120 line AST-based transform using `swc_ecma_visit`
- Helper declaration now added inline to files that need it (no separate shim file)
- Fix swc span indexing (1-indexed BytePos to 0-indexed string positions)

## Motivation

The old regex-based approach was:
- Complex (~500 lines of manual tokenization/parsing)
- Fragile (could break on edge cases with strings, comments, nested expressions)
- Coupled to `strictFunctionTypes` override for no good reason

The new AST-based approach:
- Much less code (~120 lines)
- Proper AST handling via swc_ecma_visit (handles all edge cases correctly)
- Integrates cleanly with existing kit.rs transformation pipeline
- Respects user's `strictFunctionTypes` setting

## Test plan

- [x] All existing tests pass
- [x] New unit tests for Promise.all transformation
- [x] Tested against careswitch-web (0 TypeScript errors)
- [x] Tested against forge-web (0 TypeScript errors)
- [x] Tested against careswitch-marketing (0 TypeScript errors)
- [x] Clippy clean, formatted

🤖 Generated with [Claude Code](https://claude.ai/code)