### PR TITLE
fix(transformer): preserve runes instead of lowering to expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "source-map"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1768,7 +1768,7 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "svelte-check-rs"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "camino",
  "clap",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-diagnostics"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-parser"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "insta",
  "logos",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-transformer"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "tsgo-runner"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "blake3",
  "camino",

--- a/crates/svelte-transformer/src/transform.rs
+++ b/crates/svelte-transformer/src/transform.rs
@@ -1559,7 +1559,8 @@ mod tests {
     fn test_transform_with_script() {
         let doc = parse("<script>let x = $state(0);</script>").document;
         let result = transform(&doc, TransformOptions::default());
-        assert!(result.tsx_code.contains("let x = 0"));
+        // Runes are preserved
+        assert!(result.tsx_code.contains("let x = $state(0)"));
     }
 
     #[test]
@@ -1573,7 +1574,8 @@ mod tests {
     fn test_transform_with_typescript() {
         let doc = parse("<script lang=\"ts\">let x: number = $state(0);</script>").document;
         let result = transform(&doc, TransformOptions::default());
-        assert!(result.tsx_code.contains("let x: number = 0"));
+        // Runes are preserved
+        assert!(result.tsx_code.contains("let x: number = $state(0)"));
     }
 
     #[test]

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_component.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_component.snap
@@ -140,7 +140,7 @@ declare const __svelte_any: any;
     import tippy from 'tippy.js';
     import Button from './Button.svelte';
 
-    let content = 'Hello!';
+    let content = $state('Hello!');
 
     function tooltip(content: string) {
         return (element: HTMLElement) => {

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_inline.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_inline.snap
@@ -132,7 +132,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let color = 'red';
+    let color = $state('red');
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__await_components.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__await_components.snap
@@ -141,7 +141,7 @@ declare const __svelte_any: any;
     import ErrorAlert from './ErrorAlert.svelte';
 
     type User = { id: number; name: string; avatar: string };
-    let userPromise: Promise<User> = fetch('/api/user').then(r => r.json());
+    let userPromise: Promise<User> = $state(fetch('/api/user').then(r => r.json()));
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bind_key_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bind_key_transform.snap
@@ -127,7 +127,7 @@ declare const __svelte_any: any;
 // === INSTANCE SCRIPT ===
 
     import Component from './Component.svelte';
-    let selectedKey = 'default';
+    let selectedKey = $state('default');
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bindable_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bindable_rune.snap
@@ -125,7 +125,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let { value = "default" } = ({} as __SvelteLoosen<{ value?: string }>);
+    let { value = $bindable("default") } = ({} as __SvelteLoosen<{ value?: string }>);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__binding_checked.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__binding_checked.snap
@@ -125,7 +125,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let checked = false;
+    let checked = $state(false);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__binding_value.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__binding_value.snap
@@ -125,7 +125,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let text = "";
+    let text = $state("");
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__complex_events.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__complex_events.snap
@@ -150,7 +150,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let items = ([] as string[]);
+    let items = $state<string[]>([]);
 
     function handleKeydown(event: KeyboardEvent) {
         if (event.key === 'Enter' || event.key === ' ') {

--- a/crates/svelte-transformer/tests/snapshots/snapshots__complex_props_trajectory_pattern.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__complex_props_trajectory_pattern.snap
@@ -189,12 +189,12 @@ declare const __svelte_any: any;
     }
   }>)
 
-  let step_label_positions = ((): number[] => {
+  let step_label_positions = $derived.by((): number[] => {
     const total_frames = 100
     return [1, 2, 3]
       .map((t) => Math.round(t))
       .filter((t, i, arr) => t >= 0 && t < total_frames && arr.indexOf(t) === i)
-  })()
+  })
 
 
 // === COMPONENT TYPE EXPORT ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__component_namespace.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__component_namespace.snap
@@ -145,7 +145,7 @@ declare const __svelte_any: any;
     import * as Dialog from '$lib/components/ui/dialog';
     import * as Popover from '$lib/components/ui/popover';
 
-    let open = false;
+    let open = $state(false);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__component_snippets_props.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__component_snippets_props.snap
@@ -151,7 +151,7 @@ declare const __svelte_any: any;
     import DataTable from './DataTable.svelte';
 
     type Row = { id: number; name: string; email: string };
-    let rows: Row[] = [];
+    let rows: Row[] = $state([]);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__conditional_components.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__conditional_components.snap
@@ -149,7 +149,7 @@ declare const __svelte_any: any;
         | { status: 'error'; error: Error }
         | { status: 'success'; data: string[] };
 
-    let state: State = { status: 'loading' };
+    let state: State = $state({ status: 'loading' });
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__counter_complete.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__counter_complete.snap
@@ -142,15 +142,15 @@ declare const __svelte_any: any;
 // === INSTANCE SCRIPT ===
 
     let { initial = 0 } = ({} as __SvelteLoosen<{ initial?: number }>);
-    let count = initial;
+    let count = $state(initial);
 
-    const doubled = (count * 2);
+    const doubled = $derived(count * 2);
 
     function increment() {
         count += 1;
     }
 
-    __svelte_effect(() => {
+    $effect(() => {
         console.log('Count changed:', count);
     });
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__derived_by_template_literal_comparison.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__derived_by_template_literal_comparison.snap
@@ -140,7 +140,7 @@ declare const __svelte_any: any;
   let total_frames = 100
   let step_labels = 5 as number | number[]
 
-  let step_label_positions = ((): number[] => {
+  let step_label_positions = $derived.by((): number[] => {
     if (typeof step_labels === `number`) {
       if (step_labels > 0) {
         return [1, 2, 3]
@@ -149,7 +149,7 @@ declare const __svelte_any: any;
       }
     }
     return []
-  })()
+  })
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__derived_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__derived_rune.snap
@@ -127,9 +127,9 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let count = 0;
-    let doubled = (count * 2);
-    let computed = (() => count * 3)();
+    let count = $state(0);
+    let doubled = $derived(count * 2);
+    let computed = $derived.by(() => count * 3);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__each_component_key.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__each_component_key.snap
@@ -145,7 +145,7 @@ declare const __svelte_any: any;
     import ListItem from './ListItem.svelte';
 
     type Item = { id: string; title: string; completed: boolean };
-    let items: Item[] = [];
+    let items: Item[] = $state([]);
 
     function toggle(id: string) {
         items = items.map(item =>

--- a/crates/svelte-transformer/tests/snapshots/snapshots__effect_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__effect_rune.snap
@@ -133,13 +133,13 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let count = 0;
+    let count = $state(0);
 
-    __svelte_effect(() => {
+    $effect(() => {
         console.log(count);
     });
 
-    __svelte_effect_pre(() => {
+    $effect.pre(() => {
         console.log('pre');
     });
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__event_inline.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__event_inline.snap
@@ -125,7 +125,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let count = 0;
+    let count = $state(0);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__form_complete.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__form_complete.snap
@@ -142,9 +142,9 @@ declare const __svelte_any: any;
 
     let { onsubmit } = ({} as __SvelteLoosen<{ onsubmit: (data: { email: string; password: string }) => void }>);
 
-    let email = "";
-    let password = "";
-    let isValid = (email.includes('@') && password.length >= 8);
+    let email = $state("");
+    let password = $state("");
+    let isValid = $derived(email.includes('@') && password.length >= 8);
 
     function handleSubmit(e: SubmitEvent) {
         e.preventDefault();

--- a/crates/svelte-transformer/tests/snapshots/snapshots__generic_multiple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__generic_multiple.snap
@@ -182,19 +182,19 @@ const itemDefault: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_ite
 
     let {
         mode,
-        value = (mode === 'multiple' ? [] : '') as ValueType<TMode>,
+        value = $bindable((mode === 'multiple' ? [] : '') as ValueType<TMode>),
         options,
         item = itemDefault,
     }: Props = ({} as __SvelteLoosen<Props>);
 
-    const selectedOptions = (() => {
+    const selectedOptions = $derived.by(() => {
         if (mode === 'multiple') {
             return options.filter((opt) => (value as string[]).includes(opt.value));
         } else {
             const found = options.find((f) => f.value === value);
             return found ? [found] : [];
         }
-    })();
+    });
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__generic_placeholder_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__generic_placeholder_rune.snap
@@ -127,7 +127,7 @@ declare const __svelte_any: any;
 // === INSTANCE SCRIPT ===
 function __svelte_render<T>() {
 
-    let count = 0;
+    let count = $state(0);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__generic_simple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__generic_simple.snap
@@ -133,7 +133,7 @@ declare const __svelte_any: any;
 // === INSTANCE SCRIPT ===
 function __svelte_render<T extends { id: string; label: string }>() {
 
-    let { options, selected = undefined as any } = ({} as __SvelteLoosen<{
+    let { options, selected = $bindable() } = ({} as __SvelteLoosen<{
         options: T[];
         selected?: T;
     }>);

--- a/crates/svelte-transformer/tests/snapshots/snapshots__host_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__host_rune.snap
@@ -125,7 +125,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    const el = this;
+    const el = $host();
 
 
 // === COMPONENT TYPE EXPORT ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__inspect_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__inspect_rune.snap
@@ -126,8 +126,8 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let count = 0;
-    void 0;
+    let count = $state(0);
+    $inspect(count);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__javascript_component.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__javascript_component.snap
@@ -125,7 +125,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let count = 0;
+    let count = $state(0);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__module_script.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__module_script.snap
@@ -139,7 +139,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let count = 0;
+    let count = $state(0);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_components_deep.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_components_deep.snap
@@ -139,7 +139,7 @@ declare const __svelte_any: any;
     import Middle from './Middle.svelte';
     import Inner from './Inner.svelte';
 
-    let data = { value: 42 };
+    let data = $state({ value: 42 });
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_expressions.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_expressions.snap
@@ -129,7 +129,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let items = [{ children: [1, 2, 3] }];
+    let items = $state([{ children: [1, 2, 3] }]);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_with_const_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_with_const_transform.snap
@@ -138,7 +138,7 @@ const example: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_example
 
 // === INSTANCE SCRIPT ===
 
-    let key = 'test';
+    let key = $state('test');
 
     function check(val: string): boolean {
         return val.length > 0;

--- a/crates/svelte-transformer/tests/snapshots/snapshots__special_chars.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__special_chars.snap
@@ -125,7 +125,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let message = "Hello \"world\" with 'quotes' and \n newlines";
+    let message = $state("Hello \"world\" with 'quotes' and \n newlines");
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__state_raw_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__state_raw_rune.snap
@@ -125,7 +125,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let items = [1, 2, 3];
+    let items = $state.raw([1, 2, 3]);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__state_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__state_rune.snap
@@ -127,9 +127,9 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let count = 0;
-    let name = "hello";
-    let data = { x: 1, y: 2 };
+    let count = $state(0);
+    let name = $state("hello");
+    let data = $state({ x: 1, y: 2 });
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_css_custom_property.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_css_custom_property.snap
@@ -129,8 +129,8 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let compensate = 0;
-    let theme = 'dark';
+    let compensate = $state(0);
+    let theme = $state('dark');
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===
@@ -152,11 +152,11 @@ export default __SvelteComponent_Test_;
 
 === Source Map Mappings (9) ===
   0: generated 4572..4594 -> original 18..40
-  1: generated 4594..4595 -> original 40..49
-  2: generated 4595..4613 -> original 49..67
-  3: generated 4613..4619 -> original 67..81
-  4: generated 4619..4621 -> original 81..83
-  5: generated 4752..4795 -> original 124..167
-  6: generated 4841..4842 -> original 180..181
-  7: generated 4856..4861 -> original 214..219
-  8: generated 4865..4870 -> original 238..241
+  1: generated 4594..4603 -> original 40..49
+  2: generated 4603..4621 -> original 49..67
+  3: generated 4621..4635 -> original 67..81
+  4: generated 4635..4637 -> original 81..83
+  5: generated 4768..4811 -> original 124..167
+  6: generated 4857..4858 -> original 180..181
+  7: generated 4872..4877 -> original 214..219
+  8: generated 4881..4886 -> original 238..241

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_expression.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_expression.snap
@@ -126,8 +126,8 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let myColor = 'red';
-    let width = 100;
+    let myColor = $state('red');
+    let width = $state(100);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_important.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_important.snap
@@ -125,7 +125,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let color = 'red';
+    let color = $state('red');
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_multiple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_multiple.snap
@@ -133,7 +133,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let darkMode = false;
+    let darkMode = $state(false);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_shorthand.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_shorthand.snap
@@ -126,8 +126,8 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let color = 'red';
-    let opacity = 0.5;
+    let color = $state('red');
+    let opacity = $state(0.5);
 
 
 // === COMPONENT TYPE EXPORT ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_with_attr.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_with_attr.snap
@@ -125,7 +125,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let color = 'red';
+    let color = $state('red');
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_each_block.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_each_block.snap
@@ -127,7 +127,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let items = [{ id: 1, name: 'a' }, { id: 2, name: 'b' }];
+    let items = $state([{ id: 1, name: 'a' }, { id: 2, name: 'b' }]);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_each_else.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_each_else.snap
@@ -129,7 +129,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let items: string[] = [];
+    let items: string[] = $state([]);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_if_block.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_if_block.snap
@@ -132,8 +132,8 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let show = true;
-    let user: { name: string } | null = null;
+    let show = $state(true);
+    let user: { name: string } | null = $state(null);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_if_else.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_if_else.snap
@@ -131,7 +131,7 @@ declare const __svelte_any: any;
 
 // === INSTANCE SCRIPT ===
 
-    let status: 'loading' | 'ready' | 'error' = 'loading';
+    let status: 'loading' | 'ready' | 'error' = $state('loading');
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_snippet.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_snippet.snap
@@ -137,7 +137,7 @@ const item: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_item>> = n
 
 // === INSTANCE SCRIPT ===
 
-    let items = ['a', 'b', 'c'];
+    let items = $state(['a', 'b', 'c']);
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access_with_parameter.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access_with_parameter.snap
@@ -139,7 +139,7 @@ declare const __svelte_any: any;
             }
         }
     };
-    let options = { content: "Tooltip text" };
+    let options = $state({ content: "Tooltip text" });
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_multiple_with_member_access.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_multiple_with_member_access.snap
@@ -141,7 +141,7 @@ declare const __svelte_any: any;
             return { destroy() {} };
         }
     };
-    let opts = {};
+    let opts = $state({});
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_with_parameter.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_with_parameter.snap
@@ -131,7 +131,7 @@ declare const __svelte_any: any;
     function tooltip(node: HTMLElement, content: string) {
         return { destroy() {} };
     }
-    let content = "Hello";
+    let content = $state("Hello");
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/tsgo-runner/src/runner.rs
+++ b/crates/tsgo-runner/src/runner.rs
@@ -51,6 +51,33 @@ declare global {
   declare function __svelte_effect_pre(fn: () => void | (() => void)): void;
   declare function __svelte_effect_root(fn: (...args: any[]) => any): void;
 
+  // Svelte 5 rune type declarations
+  // These match the ambient declarations in svelte/types/index.d.ts
+  declare function $state<T>(initial: T): T;
+  declare function $state<T>(): T | undefined;
+  declare namespace $state {
+    export function raw<T>(initial: T): T;
+    export function raw<T>(): T | undefined;
+    export function snapshot<T>(value: T): T;
+  }
+
+  declare function $derived<T>(expression: T): T;
+  declare namespace $derived {
+    export function by<T>(fn: () => T): T;
+  }
+
+  declare function $effect(fn: () => void | (() => void)): void;
+  declare namespace $effect {
+    export function pre(fn: () => void | (() => void)): void;
+    export function root(fn: () => (() => void)): () => void;
+    export function tracking(): boolean;
+  }
+
+  declare function $props<T>(): T;
+  declare function $bindable<T>(fallback?: T): T;
+  declare function $inspect<T>(...values: T[]): { with: (fn: (type: 'init' | 'update', ...values: T[]) => void) => void };
+  declare function $host<T extends HTMLElement = HTMLElement>(): T;
+
   type __StoreValue<S> = S extends { subscribe(fn: (value: infer T) => void): any } ? T : never;
 
   type __SvelteOptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;


### PR DESCRIPTION
## Summary

- Preserve Svelte 5 runes (`$state`, `$derived`, `$derived.by`, `$effect`, `$bindable`, `$inspect`, `$host`) as-is in transformed output
- Add ambient type declarations for all runes to the helpers file
- Match the official svelte-check transformation approach

## Root Cause

Previously, svelte-check-rs "lowered" runes to vanilla JS expressions:
- `$state(0)` → `0`
- `$derived(expr)` → `(expr)`
- `$derived.by(fn)` → `(fn)()` (IIFE!)
- `$bindable()` → `undefined as any`

The IIFE pattern for `$derived.by` caused TypeScript to evaluate execution order, triggering false "used before assigned" errors for variables referenced in `$derived` that are assigned later (e.g., via `bind:this`).

## Solution

Adopt the same approach as the official svelte-check: preserve rune calls and provide ambient type declarations. TypeScript uses these declarations to understand types without "executing" the code:

```typescript
declare function $state<T>(initial: T): T;
declare function $derived<T>(expression: T): T;
declare namespace $derived {
  export function by<T>(fn: () => T): T;
}
```

## Test plan

- [x] All 128 unit tests pass
- [x] All 85 snapshot tests updated and pass
- [x] Integration tests pass
- [x] Verified fix against [reproduction repository](https://github.com/janosh/svelte-check-rs-repro) - 0 errors

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)