### PR TITLE
feat(cli): add --no-cache mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ cargo run -p svelte-check-rs -- --workspace ./path/to/project [--emit-ts]
 - `--output json`: Machine-readable diagnostics with exact locations
 - `--timings`: Show parse/transform/check timing breakdown
 - `--cache-stats`: Show cache statistics (files written/skipped)
+- `--no-cache`: Disable per-project cache + incremental builds (fresh run)
 - `--watch`: File watcher mode (uses `notify` crate, 1s polling)
 - `--debug-paths`: Show resolved tsgo, package manager, svelte-kit paths
 - `--show-config`: Print resolved configuration (tsconfig, svelte.config.js, excludes)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "source-map"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1768,7 +1768,7 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "svelte-check-rs"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "camino",
  "clap",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-diagnostics"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-parser"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "insta",
  "logos",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-transformer"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "tsgo-runner"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "blake3",
  "camino",

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ svelte-check-rs --output human-verbose
 | `--fail-on-warnings` | Exit with error on warnings |
 | `--diagnostic-sources <LIST>` | Which diagnostics: `js`, `svelte` |
 | `--ignore <PATTERNS>` | Glob patterns to ignore |
+| `--no-cache` | Disable per-project cache + incremental builds (fresh run) |
+| `--disable-sveltekit-cache` | Disable cached .svelte-kit mirror |
+
+**Caching:** By default, svelte-check-rs writes transformed files and tsgo incremental build info to `node_modules/.cache/svelte-check-rs/`. Use `--no-cache` for a fully fresh run (useful in CI).
 
 ## Project Structure
 

--- a/crates/svelte-check-rs/src/cli.rs
+++ b/crates/svelte-check-rs/src/cli.rs
@@ -68,6 +68,10 @@ pub struct Args {
     #[arg(long = "disable-sveltekit-cache")]
     pub disable_sveltekit_cache: bool,
 
+    /// Disable all caching (tsgo cache, incremental build info, and svelte-kit cache)
+    #[arg(long = "no-cache")]
+    pub no_cache: bool,
+
     /// Show tsgo version and installation path
     #[arg(long = "tsgo-version")]
     pub tsgo_version: bool,
@@ -244,6 +248,10 @@ mod tests {
         // Test --cache-stats
         let args = Args::parse_from(["svelte-check-rs", "--cache-stats"]);
         assert!(args.cache_stats);
+
+        // Test --no-cache
+        let args = Args::parse_from(["svelte-check-rs", "--no-cache"]);
+        assert!(args.no_cache);
     }
 
     #[test]

--- a/crates/svelte-check-rs/src/orchestrator.rs
+++ b/crates/svelte-check-rs/src/orchestrator.rs
@@ -725,10 +725,11 @@ async fn run_single_check(
         transformed_count = transformed.files.len();
 
         if !transformed.files.is_empty() {
+            let use_cache = !args.no_cache;
             // Ensure SvelteKit types are generated before running tsgo
             let tsgo_start = Instant::now();
             let sync_start = Instant::now();
-            let sync_ran = match TsgoRunner::ensure_sveltekit_sync(workspace).await {
+            let sync_ran = match TsgoRunner::ensure_sveltekit_sync(workspace, use_cache).await {
                 Ok(ran) => ran,
                 Err(e) => {
                     eprintln!("Warning: {}", e);
@@ -937,12 +938,15 @@ async fn run_tsgo_check(
         .await
         .map_err(|e| OrchestratorError::TsgoError(e.to_string()))?;
 
+    let use_cache = !args.no_cache;
+    let use_sveltekit_cache = use_cache && !args.disable_sveltekit_cache;
     let runner = TsgoRunner::new(
         tsgo_path,
         workspace.to_owned(),
         args.tsconfig.clone(),
         extra_paths.clone(),
-        !args.disable_sveltekit_cache,
+        use_sveltekit_cache,
+        use_cache,
     );
 
     runner

--- a/crates/tsgo-runner/src/lib.rs
+++ b/crates/tsgo-runner/src/lib.rs
@@ -18,6 +18,7 @@
 //!         None,
 //!         HashMap::new(),
 //!         true,
+//!         true,
 //!     );
 //!
 //!     let files = TransformedFiles::new();

--- a/docs/index.html
+++ b/docs/index.html
@@ -357,6 +357,10 @@ bun pm trust svelte-check-rs</code>
                   <code>--emit-ts</code>
                   <span>Print transformed TS</span>
                 </div>
+                <div class="cli-row">
+                  <code>--no-cache</code>
+                  <span>Disable per-project cache (fresh run)</span>
+                </div>
               </div>
             </div>
             <div class="cli-group">


### PR DESCRIPTION
## Summary
- add a --no-cache flag to disable per-project cache/incremental builds and force fresh svelte-kit sync
- run tsgo from a per-run temp dir when cache is disabled
- add integration coverage and docs/AGENTS/README updates

## Testing
- cargo clippy --all-targets -- -D warnings
- cargo test -p svelte-check-rs --test integration_cache

Closes #25