### PR TITLE
fix(transformer): escape multiline quoted directives

### DIFF
--- a/crates/svelte-check-rs/tests/integration_issues.rs
+++ b/crates/svelte-check-rs/tests/integration_issues.rs
@@ -1,4 +1,4 @@
-//! Integration tests for issues #19, #20, #21.
+//! Integration tests for issues #19, #20, #21 (and others as they are added).
 //!
 //! These tests verify that:
 //! - Issue #21: Imports with colons (like `virtual:pwa-register`) don't cause parsing errors
@@ -487,6 +487,40 @@ fn test_issue_74_computed_props_missing_required_prop_reports_error() {
         message_contains: "No overload matches this call",
     };
     assert_diagnostic_present(&diagnostics, &expected);
+}
+
+// ============================================================================
+// ISSUE #77: MULTI-LINE QUOTED STYLE DIRECTIVE VALUES
+// ============================================================================
+// This test verifies that multi-line quoted style directive values do not
+// produce TypeScript parse errors in the generated output.
+//
+// Test file:
+// - test-fixtures/projects/sveltekit-bundler/src/routes/issue-77-multiline-style/+page.svelte
+#[test]
+#[serial]
+fn test_issue_77_multiline_style_directive_no_error() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let (_exit_code, diagnostics) = run_check_json(&fixture_path, "js");
+
+    assert_no_diagnostics_in_file(&diagnostics, "issue-77-multiline-style/+page.svelte");
+}
+
+// ============================================================================
+// ISSUE #77: MULTI-LINE QUOTED NORMAL ATTRIBUTE VALUES
+// ============================================================================
+// This test verifies that multi-line quoted normal attributes do not
+// produce TypeScript parse errors in the generated output.
+//
+// Test file:
+// - test-fixtures/projects/sveltekit-bundler/src/routes/issue-77-multiline-attr/+page.svelte
+#[test]
+#[serial]
+fn test_issue_77_multiline_normal_attribute_no_error() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let (_exit_code, diagnostics) = run_check_json(&fixture_path, "js");
+
+    assert_no_diagnostics_in_file(&diagnostics, "issue-77-multiline-attr/+page.svelte");
 }
 
 /// Test that wildcard exclude patterns work correctly.

--- a/crates/svelte-transformer/src/template.rs
+++ b/crates/svelte-transformer/src/template.rs
@@ -1255,10 +1255,7 @@ impl TemplateContext {
                 // For style directives and other directives, emit the expression
                 // If the expression is a quoted string literal, wrap it in quotes
                 if expr.is_quoted {
-                    let quoted = format!(
-                        "\"{}\"",
-                        expr.expression.replace('\\', "\\\\").replace('"', "\\\"")
-                    );
+                    let quoted = format!("\"{}\"", escape_js_string(&expr.expression));
                     self.emit_expression(&quoted, expr.expression_span, context);
                 } else {
                     self.emit_expression(&expr.expression, expr.expression_span, context);

--- a/crates/svelte-transformer/tests/style_directive_multiline.rs
+++ b/crates/svelte-transformer/tests/style_directive_multiline.rs
@@ -1,0 +1,27 @@
+use svelte_parser::parse;
+use svelte_transformer::{transform, TransformOptions};
+
+#[test]
+fn multiline_style_directive_string_is_escaped() {
+    let source = r#"<span
+  style:transform="rotate({angle}deg)
+  translate({dx}px, {dy}px)"
+></span>"#;
+
+    let parsed = parse(source);
+    let result = transform(
+        &parsed.document,
+        TransformOptions {
+            filename: Some("Test.svelte".to_string()),
+            source_maps: true,
+            ..Default::default()
+        },
+    );
+
+    let expected = "\"rotate({angle}deg)\\n  translate({dx}px, {dy}px)\"";
+    assert!(
+        result.tsx_code.contains(expected),
+        "expected escaped newline in quoted style directive, got:\n{}",
+        result.tsx_code
+    );
+}

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-77-multiline-attr/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-77-multiline-attr/+page.svelte
@@ -1,0 +1,4 @@
+<div
+  title="Line one
+  Line two"
+></div>

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-77-multiline-style/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-77-multiline-style/+page.svelte
@@ -1,0 +1,4 @@
+<span
+  style:transform="rotate(10deg)
+  translate(1px, 2px)"
+></span>


### PR DESCRIPTION
## Summary
- escape quoted directive values with full JS string escaping to avoid TS parse errors
- add regression unit test plus SvelteKit fixtures covering multi-line quoted directives and normal attributes

## Testing
- cargo test -p svelte-transformer --test style_directive_multiline
- cargo test -p svelte-check-rs --test integration_issues test_issue_77_multiline_style_directive_no_error
- cargo test -p svelte-check-rs --test integration_issues test_issue_77_multiline_normal_attribute_no_error
- cargo clippy --all-targets -- -D warnings
- cargo fmt

Fixes #77