### PR TITLE
fix(transformer): infer component exports for mount()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,6 +1851,9 @@ dependencies = [
  "smol_str",
  "source-map",
  "svelte-parser",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
  "thiserror",
 ]
 

--- a/crates/svelte-check-rs/tests/integration_issues.rs
+++ b/crates/svelte-check-rs/tests/integration_issues.rs
@@ -523,6 +523,23 @@ fn test_issue_77_multiline_normal_attribute_no_error() {
     assert_no_diagnostics_in_file(&diagnostics, "issue-77-multiline-attr/+page.svelte");
 }
 
+// ============================================================================
+// ISSUE #79: MOUNT() RETURN TYPE INCLUDES COMPONENT EXPORTS
+// ============================================================================
+// This test verifies that component exports declared via `export { ... }`
+// are reflected in the type of the object returned from `mount()`.
+//
+// Test file:
+// - test-fixtures/projects/sveltekit-bundler/src/lib/issue-79-mount.ts
+#[test]
+#[serial]
+fn test_issue_79_mount_exports_no_error() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let (_exit_code, diagnostics) = run_check_json(&fixture_path, "js");
+
+    assert_no_diagnostics_in_file(&diagnostics, "lib/issue-79-mount.ts");
+}
+
 /// Test that wildcard exclude patterns work correctly.
 ///
 /// Tests patterns like:

--- a/crates/svelte-transformer/Cargo.toml
+++ b/crates/svelte-transformer/Cargo.toml
@@ -11,6 +11,9 @@ source-map.workspace = true
 svelte-parser.workspace = true
 smol_str.workspace = true
 thiserror.workspace = true
+swc_common.workspace = true
+swc_ecma_ast.workspace = true
+swc_ecma_parser.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/svelte-transformer/src/component_exports.rs
+++ b/crates/svelte-transformer/src/component_exports.rs
@@ -1,0 +1,196 @@
+//! Component export extraction for Svelte 5 runes.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use swc_common::{FileName, SourceMap};
+use swc_ecma_ast::{
+    ExportNamedSpecifier, ExportSpecifier, Module, ModuleDecl, ModuleExportName, ModuleItem,
+};
+use swc_ecma_parser::{Parser, StringInput, Syntax, TsSyntax};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportedName {
+    pub exported: String,
+    pub local: String,
+}
+
+/// Extracts component exports from the instance script.
+///
+/// This looks for `export { ... }` declarations and ignores type-only exports
+/// and re-exports with `from`.
+pub fn extract_component_exports(script: &str) -> Vec<ExportedName> {
+    let Some(module) = parse_module(script) else {
+        return Vec::new();
+    };
+
+    let mut exports = Vec::new();
+    for item in module.body {
+        if let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) = item {
+            if named.src.is_some() || named.type_only {
+                continue;
+            }
+            for spec in named.specifiers {
+                let ExportSpecifier::Named(named) = spec else {
+                    continue;
+                };
+                if named.is_type_only {
+                    continue;
+                }
+                if let Some(export_name) = extract_named_export(&named) {
+                    exports.push(export_name);
+                }
+            }
+        }
+    }
+
+    exports
+}
+
+pub fn build_exports_type(exports: &[ExportedName]) -> Option<String> {
+    if exports.is_empty() {
+        return None;
+    }
+
+    let mut parts = Vec::new();
+    let mut seen = HashSet::new();
+    for export in exports {
+        if !is_valid_identifier(&export.local) {
+            continue;
+        }
+        if !seen.insert(export.exported.as_str()) {
+            continue;
+        }
+        let prop_name = if is_valid_identifier(&export.exported) {
+            export.exported.clone()
+        } else {
+            format!("\"{}\"", escape_string_literal(&export.exported))
+        };
+        parts.push(format!("{}: typeof {}", prop_name, export.local));
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(format!("{{ {} }}", parts.join(", ")))
+    }
+}
+
+fn parse_module(script: &str) -> Option<Module> {
+    let cm: Arc<SourceMap> = Default::default();
+    let fm = cm.new_source_file(
+        FileName::Custom("svelte-instance-script".into()).into(),
+        script.to_string(),
+    );
+    let syntax = Syntax::Typescript(TsSyntax {
+        tsx: false,
+        ..Default::default()
+    });
+    let mut parser = Parser::new(syntax, StringInput::from(&*fm), None);
+    parser.parse_module().ok()
+}
+
+fn extract_named_export(named: &ExportNamedSpecifier) -> Option<ExportedName> {
+    let local = module_export_name_to_ident(&named.orig)?;
+    let exported = named
+        .exported
+        .as_ref()
+        .map(module_export_name_to_string)
+        .unwrap_or_else(|| local.clone());
+
+    Some(ExportedName { exported, local })
+}
+
+fn module_export_name_to_ident(name: &ModuleExportName) -> Option<String> {
+    match name {
+        ModuleExportName::Ident(ident) => Some(ident.sym.to_string()),
+        ModuleExportName::Str(_) => None,
+    }
+}
+
+fn module_export_name_to_string(name: &ModuleExportName) -> String {
+    match name {
+        ModuleExportName::Ident(ident) => ident.sym.to_string(),
+        ModuleExportName::Str(value) => value.value.to_string_lossy().into_owned(),
+    }
+}
+
+fn is_valid_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    let first = match chars.next() {
+        Some(c) => c,
+        None => return false,
+    };
+    if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+}
+
+fn escape_string_literal(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_simple_exports() {
+        let script = "let count = 0; export { count, name };";
+        let exports = extract_component_exports(script);
+        assert_eq!(exports.len(), 2);
+        assert!(exports
+            .iter()
+            .any(|e| e.exported == "count" && e.local == "count"));
+        assert!(exports
+            .iter()
+            .any(|e| e.exported == "name" && e.local == "name"));
+    }
+
+    #[test]
+    fn extracts_aliased_exports() {
+        let script = "let count = 0; export { count as total };";
+        let exports = extract_component_exports(script);
+        assert_eq!(
+            exports,
+            vec![ExportedName {
+                exported: "total".to_string(),
+                local: "count".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn ignores_type_only_exports() {
+        let script = "export type { Foo }; export { count };";
+        let exports = extract_component_exports(script);
+        assert_eq!(exports.len(), 1);
+        assert_eq!(exports[0].exported, "count");
+    }
+
+    #[test]
+    fn ignores_reexports() {
+        let script = "export { count } from './module'; export { name };";
+        let exports = extract_component_exports(script);
+        assert_eq!(exports.len(), 1);
+        assert_eq!(exports[0].exported, "name");
+    }
+
+    #[test]
+    fn builds_exports_type() {
+        let exports = vec![
+            ExportedName {
+                exported: "count".to_string(),
+                local: "count".to_string(),
+            },
+            ExportedName {
+                exported: "name".to_string(),
+                local: "name".to_string(),
+            },
+        ];
+        let ty = build_exports_type(&exports).unwrap();
+        assert!(ty.contains("count: typeof count"));
+        assert!(ty.contains("name: typeof name"));
+    }
+}

--- a/crates/svelte-transformer/src/lib.rs
+++ b/crates/svelte-transformer/src/lib.rs
@@ -26,6 +26,7 @@
 //! println!("TypeScript output:\n{}", result.tsx_code);
 //! ```
 
+mod component_exports;
 mod module;
 mod props;
 mod runes;
@@ -34,6 +35,7 @@ mod template;
 mod transform;
 mod types;
 
+pub use component_exports::{build_exports_type, extract_component_exports, ExportedName};
 pub use module::{transform_module, ModuleTransformResult};
 pub use props::{extract_props_info, generate_props_type, PropProperty, PropsInfo};
 pub use runes::{transform_runes, RuneInfo, RuneKind, RuneMapping, RuneTransformResult};

--- a/test-fixtures/projects/sveltekit-bundler/src/lib/components/Issue79Component.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/lib/components/Issue79Component.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    interface Props {
+        count?: number;
+        name?: string;
+    }
+
+    let { count = $bindable(0), name = $bindable("World") }: Props = $props();
+
+    export { count, name };
+</script>
+
+<button>
+    Hello {name}! Count: {count}
+</button>

--- a/test-fixtures/projects/sveltekit-bundler/src/lib/issue-79-mount.ts
+++ b/test-fixtures/projects/sveltekit-bundler/src/lib/issue-79-mount.ts
@@ -1,0 +1,11 @@
+import { mount } from "svelte";
+import Issue79Component from "$lib/components/Issue79Component.svelte";
+
+const counter = mount(Issue79Component, {
+  target: document.body,
+  props: { count: 5, name: "Test" },
+});
+
+void counter.count;
+void counter.name;
+counter.count = 10;


### PR DESCRIPTION
**Summary**
- infer component export types from instance script exports and plumb into mount() return type
- add fixture + integration test coverage for issue #79
- switch export extraction to SWC parsing for correctness

**Details**
- parse instance script with SWC to collect `export { ... }` specifiers (skip type-only and re-exports)
- include exports type in generated component type and render return

**Testing**
- cargo test
- cargo clippy --all-targets -- -D warnings
- cargo build

Fixes #79
