### PR TITLE
feat(tsgo): invalidate cache when dependencies change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bun-runner"
-version = "0.6.10"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "camino",
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "source-map"
-version = "0.6.10"
+version = "0.7.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1782,7 +1782,7 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "svelte-check-rs"
-version = "0.6.10"
+version = "0.7.0"
 dependencies = [
  "bun-runner",
  "camino",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-diagnostics"
-version = "0.6.10"
+version = "0.7.0"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-parser"
-version = "0.6.10"
+version = "0.7.0"
 dependencies = [
  "insta",
  "logos",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "svelte-transformer"
-version = "0.6.10"
+version = "0.7.0"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "tsgo-runner"
-version = "0.6.10"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "camino",

--- a/crates/svelte-check-rs/src/orchestrator.rs
+++ b/crates/svelte-check-rs/src/orchestrator.rs
@@ -805,6 +805,11 @@ async fn run_single_check(
 
         if !transformed.files.is_empty() {
             let use_cache = !args.no_cache;
+            if use_cache {
+                if let Err(err) = TsgoRunner::ensure_dependency_cache(workspace) {
+                    eprintln!("Warning: {}", err);
+                }
+            }
             // Ensure SvelteKit types are generated before running tsgo
             let tsgo_start = Instant::now();
             let sync_start = Instant::now();


### PR DESCRIPTION
## Summary

- Add dependency cache invalidation to clear stale TypeScript results after dependency updates
- Track lockfile hashes (bun.lock, pnpm-lock.yaml, yarn.lock, package-lock.json, etc.)
- Track node_modules markers (.package-lock.json, .yarn-integrity, .modules.yaml, etc.)
- Track node_modules directory mtime for reinstall detection

## Details

When caching is enabled, `ensure_dependency_cache()` is called before type-checking. It computes a manifest of dependency state and compares with the previous run. If changed, the entire project cache is cleared.

**Files tracked:**
- Lockfiles: `bun.lockb`, `bun.lock`, `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `npm-shrinkwrap.json`
- Falls back to `package.json` hash if no lockfile exists
- node_modules markers: `.package-lock.json`, `.yarn-integrity`, `.yarn-state.yml`, `.modules.yaml`, `.pnpm/lock.yaml`
- node_modules directory mtime and `.bin` entries hash

## Testing

Added two integration tests:
- `test_lockfile_change_invalidates_cache` - verifies lockfile changes clear cache
- `test_node_modules_change_invalidates_cache` - verifies node_modules changes clear cache

All 11 cache integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)