### PR TITLE
fix(transformer): preserve type narrowing from script in templates

### DIFF
--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_component.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_component.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -164,9 +165,12 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import tippy from 'tippy.js';
+import Button from './Button.svelte';
+async function __svelte_render() {
 
-    import tippy from 'tippy.js';
-    import Button from './Button.svelte';
+                                 
+                                         
 
     let content = $state('Hello!');
 
@@ -178,21 +182,21 @@ declare module "svelte" {
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   { const __component_0 = __svelte_ensure_component(Button); __component_0(__svelte_any(), {
     [Symbol("@attach")]: tooltip(content),
     children: () => {
       return __svelte_snippet_return;
     },
   }); }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 5 ===
+=== Source Map Mappings: 7 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_element.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_element.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -157,8 +158,10 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import type { Attachment } from 'svelte/attachments';
+async function __svelte_render() {
 
-    import type { Attachment } from 'svelte/attachments';
+                                                         
 
     const myAttachment: Attachment = (element) => {
         console.log(element.nodeName);
@@ -166,16 +169,16 @@ declare module "svelte" {
     };
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_ensure_attachment(myAttachment, null as unknown as ElementTagNameMap["div"]);
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 2 ===
+=== Source Map Mappings: 3 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_inline.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_inline.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -159,13 +160,12 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let color = $state('red');
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("canvas", {}, {
     width: 32,
     height: 32,
@@ -174,11 +174,13 @@ async function __svelte_template_check__() {
         const context = canvas.getContext('2d');
         context.fillStyle = color;
     }, null as unknown as ElementTagNameMap["canvas"]);
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_source_mapping.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_source_mapping.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 60
 expression: output
 ---
 === Source ===
@@ -152,22 +153,23 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     const myAttach = (el: Element) => { el.id = 'test'; };
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_ensure_attachment(myAttach, null as unknown as ElementTagNameMap["div"]);
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
 === Source Map Mappings (2) ===
-  0: generated 5963..6023 -> original 18..78
-  1: generated 6181..6189 -> original 103..111
+  0: generated 5998..6058 -> original 18..78
+  1: generated 6120..6128 -> original 103..111

--- a/crates/svelte-transformer/tests/snapshots/snapshots__await_components.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__await_components.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -163,18 +164,20 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import Skeleton from './Skeleton.svelte';
+import UserCard from './UserCard.svelte';
+import ErrorAlert from './ErrorAlert.svelte';
+async function __svelte_render() {
 
-    import Skeleton from './Skeleton.svelte';
-    import UserCard from './UserCard.svelte';
-    import ErrorAlert from './ErrorAlert.svelte';
+                                             
+                                             
+                                                 
 
     type User = { id: number; name: string; avatar: string };
     let userPromise: Promise<User> = $state(fetch('/api/user').then(r => r.json()));
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __await_0 = userPromise;
   {
     // pending
@@ -197,12 +200,14 @@ async function __svelte_template_check__() {
       error,
     }); }
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 10 ===
+=== Source Map Mappings: 13 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bind_key_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bind_key_transform.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -153,24 +154,26 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import Component from './Component.svelte';
+async function __svelte_render() {
 
-    import Component from './Component.svelte';
+                                               
     let selectedKey = $state('default');
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   { const __component_0 = __svelte_ensure_component(Component); __component_0(__svelte_any(), {
     key: undefined as any,
   }); }
   selectedKey;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 6 ===
+=== Source Map Mappings: 7 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bindable_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bindable_rune.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,21 +153,22 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let { value = $bindable("default") } = ({} as __SvelteLoosen<{ value?: string }>);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("input", {}, {
     "bind:value": __svelte_any,
   });
+return { props: null as any as __SvelteOptionalProps<{ value?: string }, "value">, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<__SvelteOptionalProps<{ value?: string }, "value">>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__binding_checked.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__binding_checked.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,22 +153,23 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let checked = $state(false);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("input", {}, {
     type: "checkbox",
     "bind:checked": __svelte_any,
   });
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__binding_value.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__binding_value.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,22 +153,23 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let text = $state("");
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("input", {}, {
     "bind:value": __svelte_any,
   });
   text;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__comment_in_attr_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__comment_in_attr_transform.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,21 +153,22 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let items: any[] = [];
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("div", {}, {
     data: /* TODO: fix typing */ items as any,
   });
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__complex_events.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__complex_events.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -177,6 +178,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let items = $state<string[]>([]);
 
@@ -188,9 +190,7 @@ declare module "svelte" {
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("div", {}, {
     role: "button",
     tabindex: 0,
@@ -208,11 +208,13 @@ async function __svelte_template_check__() {
         }
     },
   });
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__complex_props_trajectory_pattern.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__complex_props_trajectory_pattern.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -179,6 +180,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
   type EventHandlers = {
     on_play?: () => void
@@ -224,9 +226,7 @@ declare module "svelte" {
       .filter((t, i, arr) => t >= 0 && t < total_frames && arr.indexOf(t) === i)
   })
 
-
-// === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<EventHandlers & {
+return { props: null as any as EventHandlers & {
     trajectory?: unknown
     layout?: `auto` | `horizontal` | `vertical`
     display_mode?:
@@ -239,8 +239,13 @@ type __SvelteProps_Test_ = __SvelteLoosen<EventHandlers & {
       energy?: string
       [key: string]: string | undefined
     }
-  }>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+  }, exports: {}, slots: {}, events: {} };
+}
+
+// === COMPONENT TYPE EXPORT ===
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__component_css_custom_props.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__component_css_custom_props.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,22 +153,24 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import Box from './Box.svelte';
+async function __svelte_render() {
 
-  import Box from './Box.svelte';
+                                 
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   { const __component_0 = __svelte_ensure_component(Box); __component_0(__svelte_any(), {
     ...__svelte_css_prop({ "--some-css-var": "blue" }),
   }); }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 2 ===
+=== Source Map Mappings: 3 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__component_namespace.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__component_namespace.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -169,16 +170,17 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import * as Dialog from '$lib/components/ui/dialog';
+import * as Popover from '$lib/components/ui/popover';
+async function __svelte_render() {
 
-    import * as Dialog from '$lib/components/ui/dialog';
-    import * as Popover from '$lib/components/ui/popover';
+                                                        
+                                                          
 
     let open = $state(false);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   { const __component_0 = __svelte_ensure_component(Dialog.Root); __component_0(__svelte_any(), {
     open: undefined as any,
     children: () => {
@@ -225,12 +227,14 @@ async function __svelte_template_check__() {
       return __svelte_snippet_return;
     },
   }); }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 13 ===
+=== Source Map Mappings: 15 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__component_snippets_props.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__component_snippets_props.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -175,16 +176,16 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import DataTable from './DataTable.svelte';
+async function __svelte_render() {
 
-    import DataTable from './DataTable.svelte';
+                                               
 
     type Row = { id: number; name: string; email: string };
     let rows: Row[] = $state([]);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   { const __component_0 = __svelte_ensure_component(DataTable); __component_0(__svelte_any(), {
     rows,
     header: () => {
@@ -203,12 +204,14 @@ async function __svelte_template_check__() {
       return __svelte_snippet_return;
     },
   }); }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 10 ===
+=== Source Map Mappings: 11 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__conditional_components.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__conditional_components.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -167,10 +168,14 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import LoadingSpinner from './LoadingSpinner.svelte';
+import ErrorMessage from './ErrorMessage.svelte';
+import DataDisplay from './DataDisplay.svelte';
+async function __svelte_render() {
 
-    import LoadingSpinner from './LoadingSpinner.svelte';
-    import ErrorMessage from './ErrorMessage.svelte';
-    import DataDisplay from './DataDisplay.svelte';
+                                                         
+                                                     
+                                                   
 
     type State =
         | { status: 'loading' }
@@ -180,9 +185,7 @@ declare module "svelte" {
     let state: State = $state({ status: 'loading' });
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   if (state.status === 'loading') {
     { const __component_0 = __svelte_ensure_component(LoadingSpinner); __component_0(__svelte_any(), {
     }); }
@@ -195,12 +198,14 @@ async function __svelte_template_check__() {
       items: state.data,
     }); }
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 12 ===
+=== Source Map Mappings: 15 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__const_arrow_function_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__const_arrow_function_transform.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -156,23 +157,24 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let condition = true;
     let value: string | null = 'test';
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   if (condition) {
     const is_valid = (val: string | null): boolean => !val || val === 'none';
     is_valid(value);
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__const_iife_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__const_iife_transform.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -161,6 +162,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let condition = true;
     let some_check = false;
@@ -168,9 +170,7 @@ declare module "svelte" {
     let valueB = 'B';
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   if (condition) {
     const computed_value = (() => {
         if (some_check) return valueA
@@ -178,11 +178,13 @@ async function __svelte_template_check__() {
     })();
     computed_value;
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__counter_complete.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__counter_complete.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 81
 expression: output
 ---
 === Source (Counter.svelte) ===
@@ -168,6 +169,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let { initial = 0 } = ({} as __SvelteLoosen<{ initial?: number }>);
     let count = $state(initial);
@@ -183,9 +185,7 @@ declare module "svelte" {
     });
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("div", {}, {
     class: "counter",
   });
@@ -194,11 +194,13 @@ async function __svelte_template_check__() {
   });
   count;
   doubled;
+return { props: null as any as __SvelteOptionalProps<{ initial?: number }, "initial">, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Counter_ = __SvelteLoosen<__SvelteOptionalProps<{ initial?: number }, "initial">>;
-declare const __SvelteComponent_Counter_: __SvelteComponent<__SvelteProps_Counter_>;
+type __SvelteProps_Counter_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Counter_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Counter_: __SvelteComponent<__SvelteProps_Counter_, __SvelteExports_Counter_>;
 export default __SvelteComponent_Counter_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__derived_by_template_literal_comparison.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__derived_by_template_literal_comparison.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -164,6 +165,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
   let total_frames = 100
   let step_labels = 5 as number | number[]
@@ -180,15 +182,15 @@ declare module "svelte" {
   })
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   step_label_positions.length;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__derived_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__derived_rune.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -154,22 +155,23 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let count = $state(0);
     let doubled = $derived(count * 2);
     let computed = $derived.by(() => count * 3);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   doubled;
   computed;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__each_complex_destructure_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__each_complex_destructure_transform.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -165,6 +166,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     interface Item {
         title: string;
@@ -180,9 +182,7 @@ declare module "svelte" {
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __each_0 = data.filter((itm) => itm.value !== undefined);
   for (const { title, value, unit, fmt = default_fmt } of __each_0) {
     title + value + unit;
@@ -190,11 +190,13 @@ async function __svelte_template_check__() {
     fmt(value);
     unit;
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__each_component_key.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__each_component_key.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -169,8 +170,10 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import ListItem from './ListItem.svelte';
+async function __svelte_render() {
 
-    import ListItem from './ListItem.svelte';
+                                             
 
     type Item = { id: string; title: string; completed: boolean };
     let items: Item[] = $state([]);
@@ -182,9 +185,7 @@ declare module "svelte" {
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __each_0 = items;
   for (const [index, item] of __svelte_each_indexed(__each_0)) {
     item.id;
@@ -194,12 +195,14 @@ async function __svelte_template_check__() {
       onToggle: () => toggle(item.id),
     }); }
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 10 ===
+=== Source Map Mappings: 11 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__effect_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__effect_rune.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -160,6 +161,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let count = $state(0);
 
@@ -172,15 +174,15 @@ declare module "svelte" {
     });
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   count;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__event_inline.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__event_inline.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,21 +153,22 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let count = $state(0);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("button", {}, {
     onclick: () => count++,
   });
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__event_on_directive.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__event_on_directive.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -154,23 +155,24 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     function handleInput(e: Event) {
         console.log((e.target as HTMLInputElement).value);
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("input", {}, {
     "on:input": handleInput,
   });
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__event_reference.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__event_reference.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -154,23 +155,24 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     function handleClick(e: MouseEvent) {
         console.log(e.target);
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("button", {}, {
     onclick: handleClick,
   });
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__form_complete.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__form_complete.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 81
 expression: output
 ---
 === Source (LoginForm.svelte) ===
@@ -167,6 +168,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let { onsubmit } = ({} as __SvelteLoosen<{ onsubmit: (data: { email: string; password: string }) => void }>);
 
@@ -182,9 +184,7 @@ declare module "svelte" {
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("form", {}, {
     onsubmit: handleSubmit,
   });
@@ -203,11 +203,13 @@ async function __svelte_template_check__() {
   __svelte_create_element("button", {}, {
     disabled: !isValid,
   });
+return { props: null as any as { onsubmit: (data: { email: string; password: string }) => void }, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_LoginForm_ = __SvelteLoosen<{ onsubmit: (data: { email: string; password: string }) => void }>;
-declare const __SvelteComponent_LoginForm_: __SvelteComponent<__SvelteProps_LoginForm_>;
+type __SvelteProps_LoginForm_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_LoginForm_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_LoginForm_: __SvelteComponent<__SvelteProps_LoginForm_, __SvelteExports_LoginForm_>;
 export default __SvelteComponent_LoginForm_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__generic_multiple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__generic_multiple.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 81
 expression: output
 ---
 === Source (Combobox.svelte) ===
@@ -190,14 +191,12 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
-import CheckIcon from '@lucide/svelte/icons/check';import type { Snippet } from 'svelte';function __svelte_render<T extends {label: string; value: string}, TMode extends 'single' | 'multiple'>() {
-// === SNIPPET DECLARATIONS ===
-function __svelte_snippet_params_itemDefault(option: T) {}
-const itemDefault: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_itemDefault>> = null as any;
+import CheckIcon from '@lucide/svelte/icons/check';
+import type { Snippet } from 'svelte';
+async function __svelte_render<T extends {label: string; value: string}, TMode extends 'single' | 'multiple'>() {
 
-
-    
-    
+                                                       
+                                          
 
     type ValueType<TMode extends 'single' | 'multiple'> = TMode extends 'single' ? string : string[];
 
@@ -225,9 +224,7 @@ const itemDefault: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_ite
     });
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __each_0 = selectedOptions;
   for (const option of __each_0) {
     item(option);
@@ -239,18 +236,17 @@ async function __svelte_template_check__() {
     option.label;
     return __svelte_snippet_return;
   }
-}
 return { props: null as any as __SvelteOptionalProps<Props, "value" | "item">, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Combobox_<T extends {label: string; value: string}, TMode extends 'single' | 'multiple'> = ReturnType<typeof __svelte_render<T, TMode>>["props"];
+type __SvelteProps_Combobox_<T extends {label: string; value: string}, TMode extends 'single' | 'multiple'> = Awaited<ReturnType<typeof __svelte_render<T, TMode>>>["props"];
 declare const __SvelteComponent_Combobox_: {
-<T extends {label: string; value: string}, TMode extends 'single' | 'multiple'>(this: void, internals: any, props: __SvelteProps_Combobox_<T, TMode> & __SvelteCssProps): ReturnType<typeof __svelte_render<T, TMode>>["exports"];
+<T extends {label: string; value: string}, TMode extends 'single' | 'multiple'>(this: void, internals: any, props: __SvelteProps_Combobox_<T, TMode> & __SvelteCssProps): Awaited<ReturnType<typeof __svelte_render<T, TMode>>>["exports"];
 element?: typeof HTMLElement;
 z_$$bindings?: any;
 };
 export default __SvelteComponent_Combobox_;
 
 
-=== Source Map Mappings: 12 ===
+=== Source Map Mappings: 14 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__generic_placeholder_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__generic_placeholder_rune.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 81
 expression: output
 ---
 === Source (Placeholder.svelte) ===
@@ -153,23 +154,20 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
-function __svelte_render<T>() {
+async function __svelte_render<T>() {
 
     let count = $state(0);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   count;
-}
 return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Placeholder_<T> = ReturnType<typeof __svelte_render<T>>["props"];
+type __SvelteProps_Placeholder_<T> = Awaited<ReturnType<typeof __svelte_render<T>>>["props"];
 declare const __SvelteComponent_Placeholder_: {
-<T>(this: void, internals: any, props: __SvelteProps_Placeholder_<T> & __SvelteCssProps): ReturnType<typeof __svelte_render<T>>["exports"];
+<T>(this: void, internals: any, props: __SvelteProps_Placeholder_<T> & __SvelteCssProps): Awaited<ReturnType<typeof __svelte_render<T>>>["exports"];
 element?: typeof HTMLElement;
 z_$$bindings?: any;
 };

--- a/crates/svelte-transformer/tests/snapshots/snapshots__generic_simple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__generic_simple.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 81
 expression: output
 ---
 === Source (Select.svelte) ===
@@ -159,7 +160,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
-function __svelte_render<T extends { id: string; label: string }>() {
+async function __svelte_render<T extends { id: string; label: string }>() {
 
     let { options, selected = $bindable() } = ({} as __SvelteLoosen<{
         options: T[];
@@ -167,9 +168,7 @@ function __svelte_render<T extends { id: string; label: string }>() {
     }>);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __each_0 = options;
   for (const option of __each_0) {
     __svelte_create_element("button", {}, {
@@ -177,7 +176,6 @@ async function __svelte_template_check__() {
     });
     option.label;
   }
-}
 return { props: null as any as __SvelteOptionalProps<{
         options: T[];
         selected?: T;
@@ -185,9 +183,9 @@ return { props: null as any as __SvelteOptionalProps<{
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Select_<T extends { id: string; label: string }> = ReturnType<typeof __svelte_render<T>>["props"];
+type __SvelteProps_Select_<T extends { id: string; label: string }> = Awaited<ReturnType<typeof __svelte_render<T>>>["props"];
 declare const __SvelteComponent_Select_: {
-<T extends { id: string; label: string }>(this: void, internals: any, props: __SvelteProps_Select_<T> & __SvelteCssProps): ReturnType<typeof __svelte_render<T>>["exports"];
+<T extends { id: string; label: string }>(this: void, internals: any, props: __SvelteProps_Select_<T> & __SvelteCssProps): Awaited<ReturnType<typeof __svelte_render<T>>>["exports"];
 element?: typeof HTMLElement;
 z_$$bindings?: any;
 };

--- a/crates/svelte-transformer/tests/snapshots/snapshots__host_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__host_rune.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,13 +153,17 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     const el = $host();
 
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
+}
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__inspect_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__inspect_rune.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -153,20 +154,21 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let count = $state(0);
     $inspect(count);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   count;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__javascript_component.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__javascript_component.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 81
 expression: output
 ---
 === Source (Simple.svelte) ===
@@ -152,22 +153,23 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let count = $state(0);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("button", {}, {
     onclick: () => count++,
   });
   count;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Simple_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Simple_: __SvelteComponent<__SvelteProps_Simple_>;
+type __SvelteProps_Simple_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Simple_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Simple_: __SvelteComponent<__SvelteProps_Simple_, __SvelteExports_Simple_>;
 export default __SvelteComponent_Simple_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__layout_children.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__layout_children.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 81
 expression: output
 ---
 === Source (+layout.svelte) ===
@@ -159,26 +160,28 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import favicon from '$lib/assets/favicon.svg';
+async function __svelte_render() {
 
-	import favicon from '$lib/assets/favicon.svg';
+	                                              
 
 	let { children } = ({} as __SvelteLoosen<LayoutProps>);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("link", {}, {
     rel: "icon",
     href: favicon,
   });
   children();
+return { props: null as any as { children: unknown }, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Layout_ = __SvelteLoosen<{ children: unknown }>;
-declare const __SvelteComponent_Layout_: __SvelteComponent<__SvelteProps_Layout_>;
+type __SvelteProps_Layout_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Layout_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Layout_: __SvelteComponent<__SvelteProps_Layout_, __SvelteExports_Layout_>;
 export default __SvelteComponent_Layout_;
 
 
-=== Source Map Mappings: 7 ===
+=== Source Map Mappings: 8 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__module_script.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__module_script.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -166,19 +167,20 @@ declare module "svelte" {
     }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let count = $state(0);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   VERSION;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_components_deep.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_components_deep.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -162,17 +163,19 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import Outer from './Outer.svelte';
+import Middle from './Middle.svelte';
+import Inner from './Inner.svelte';
+async function __svelte_render() {
 
-    import Outer from './Outer.svelte';
-    import Middle from './Middle.svelte';
-    import Inner from './Inner.svelte';
+                                       
+                                         
+                                       
 
     let data = $state({ value: 42 });
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   { const __component_0 = __svelte_ensure_component(Outer); __component_0(__svelte_any(), {
     prop: data,
     children: () => {
@@ -191,12 +194,14 @@ async function __svelte_template_check__() {
     },
   }); }
   data.value;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 11 ===
+=== Source Map Mappings: 14 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_expressions.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_expressions.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -156,13 +157,12 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let items = $state([{ children: [1, 2, 3] }]);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __each_0 = items;
   for (const item of __each_0) {
     const __each_1 = item.children;
@@ -170,11 +170,13 @@ async function __svelte_template_check__() {
       child;
     }
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_template_literal_complex.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_template_literal_complex.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -158,6 +159,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     const routes = files
         .map((filename) => {
@@ -168,15 +170,15 @@ declare module "svelte" {
     if (routes.length === 0) console.error(`No routes found: ${routes.length}`);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   routes.length;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_template_literal_in_expression.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_template_literal_in_expression.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -156,6 +157,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     // Nested template literals inside template expressions
     const path = `/${parts.join(`/`)}`;
@@ -164,15 +166,15 @@ declare module "svelte" {
     console.log(`test`);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   path;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_template_literal_multiple_levels.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_template_literal_multiple_levels.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -153,21 +154,22 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     const deep = `outer ${`middle ${`inner`}`}`;
     const after = `still works`;
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   deep;
   after;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_comment_before.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_comment_before.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -155,6 +156,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     // See: issue-28 - comment before props
     const flag = true;
@@ -162,15 +164,15 @@ declare module "svelte" {
     let { children } = ({} as __SvelteLoosen<Record<string, unknown>>);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   children();
+return { props: null as any as { children: unknown }, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{ children: unknown }>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_generic.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_generic.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 81
 expression: output
 ---
 === Source (Greeting.svelte) ===
@@ -152,20 +153,21 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let { name, greeting = "Hello" } = ({} as __SvelteLoosen<{ name: string; greeting?: string }>);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   greeting;
   name;
+return { props: null as any as __SvelteOptionalProps<{ name: string; greeting?: string }, "greeting">, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Greeting_ = __SvelteLoosen<__SvelteOptionalProps<{ name: string; greeting?: string }, "greeting">>;
-declare const __SvelteComponent_Greeting_: __SvelteComponent<__SvelteProps_Greeting_>;
+type __SvelteProps_Greeting_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Greeting_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Greeting_: __SvelteComponent<__SvelteProps_Greeting_, __SvelteExports_Greeting_>;
 export default __SvelteComponent_Greeting_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_rest.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_rest.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,22 +153,23 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let { class: className, ...rest } = ({} as __SvelteLoosen<{ class?: string } & Record<string, unknown>>);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("div", {}, {
     class: className,
   });
   rest;
+return { props: null as any as { class?: string } & Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{ class?: string } & Record<string, unknown>>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_rest_loosened_annotation.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_rest_loosened_annotation.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -154,22 +155,23 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     type Foo = { foo: string };
     type Bar<T> = T & Record<string, unknown>;
     let { foo, ...rest }: __SvelteLoosen<Foo & Bar<{ baz: string }>> = ({} as __SvelteLoosen<Foo & Bar<{ baz: string }>>);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   rest;
   foo;
+return { props: null as any as Foo & Bar<{ baz: string }>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<Foo & Bar<{ baz: string }>>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_rune.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,20 +153,21 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let { name, count = 0 } = ({} as __SvelteLoosen<{ name: string; count?: number }>);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   name;
   count;
+return { props: null as any as __SvelteOptionalProps<{ name: string; count?: number }, "count">, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<__SvelteOptionalProps<{ name: string; count?: number }, "count">>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_template_literal_defaults.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_template_literal_defaults.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -156,6 +157,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
   let {
     layout = `auto`,
@@ -168,13 +170,16 @@ declare module "svelte" {
     display_mode?: `structure+scatter` | `structure` | `scatter`
   }>)
 
-
-// === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<__SvelteOptionalProps<{
+return { props: null as any as __SvelteOptionalProps<{
     layout?: `auto` | `horizontal` | `vertical`
     display_mode?: `structure+scatter` | `structure` | `scatter`
-  }, "layout" | "display_mode">>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+  }, "layout" | "display_mode">, exports: {}, slots: {}, events: {} };
+}
+
+// === COMPONENT TYPE EXPORT ===
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_type_annotation.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_type_annotation.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 81
 expression: output
 ---
 === Source (Counter.svelte) ===
@@ -153,23 +154,24 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     type Props = { count: number; onchange?: (n: number) => void };
     let { count, onchange }: Props = ({} as __SvelteLoosen<Props>);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("button", {}, {
     onclick: () => onchange?.(count + 1),
   });
   count;
+return { props: null as any as Props, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Counter_ = __SvelteLoosen<Props>;
-declare const __SvelteComponent_Counter_: __SvelteComponent<__SvelteProps_Counter_>;
+type __SvelteProps_Counter_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Counter_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Counter_: __SvelteComponent<__SvelteProps_Counter_, __SvelteExports_Counter_>;
 export default __SvelteComponent_Counter_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_array_destructure_trailing_comma.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_array_destructure_trailing_comma.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -157,20 +158,13 @@ declare module "svelte" {
   ): Exports;
 }
 
-// === SNIPPET DECLARATIONS ===
-function __svelte_snippet_params_pair(
-    [num, str]: Pair,
-) {}
-const pair: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_pair>> = null as any;
-
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     type Pair = [number, string];
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   function pair(__snippet_params_0: any) {
     const [num, str]: Pair = __snippet_params_0;
     num;
@@ -178,11 +172,13 @@ async function __svelte_template_check__() {
     return __svelte_snippet_return;
   }
   pair([42, "hello"]);
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_component_prop_trailing_comma.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_component_prop_trailing_comma.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -163,8 +164,10 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import Table from './Table.svelte';
+async function __svelte_render() {
 
-    import Table from './Table.svelte';
+                                       
 
     interface RowProps {
         id: number
@@ -172,9 +175,7 @@ declare module "svelte" {
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   { const __component_0 = __svelte_ensure_component(Table); __component_0(__svelte_any(), {
     row: (
         { id, name }: RowProps,
@@ -184,12 +185,14 @@ async function __svelte_template_check__() {
       return __svelte_snippet_return;
     },
   }); }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 5 ===
+=== Source Map Mappings: 6 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_store_typeof.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_store_typeof.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -156,31 +157,29 @@ declare module "svelte" {
   ): Exports;
 }
 
-// === SNIPPET DECLARATIONS ===
-function __svelte_snippet_params_mySnippet(value: __StoreValue<typeof formData>["prop"]) {}
-const mySnippet: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_mySnippet>> = null as any;
-
 // === INSTANCE SCRIPT ===
+import { formStore } from './stores';
+async function __svelte_render() {
+    let $formData!: __StoreValue<typeof formData>;
 
-    import { formStore } from './stores';
+                                         
     const formData = formStore;
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
-  let $formData = __svelte_store_get(formData);
+// === TEMPLATE TYPE-CHECK ===
   function mySnippet(value: typeof $formData.prop) {
     value;
     return __svelte_snippet_return;
   }
   mySnippet($formData.prop);
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 3 ===
+=== Source Map Mappings: 4 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_typed_destructure_multiline_trailing_comma.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_typed_destructure_multiline_trailing_comma.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -171,13 +172,8 @@ declare module "svelte" {
   ): Exports;
 }
 
-// === SNIPPET DECLARATIONS ===
-function __svelte_snippet_params_user_content(
-  { x_scale, y_scale, width, height, padding }: UserContentProps,
-) {}
-const user_content: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_user_content>> = null as any;
-
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     interface UserContentProps {
         x_scale: (n: number) => number
@@ -188,9 +184,7 @@ const user_content: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_us
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   function user_content(__snippet_params_0: any) {
     const { x_scale, y_scale, width, height, padding }: UserContentProps = __snippet_params_0;
     const x0 = x_scale(0);
@@ -210,11 +204,13 @@ async function __svelte_template_check__() {
     height: 300,
     padding: { top: 10, left: 20 },
 });
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_typed_destructure_trailing_comma.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_typed_destructure_trailing_comma.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -160,13 +161,8 @@ declare module "svelte" {
   ): Exports;
 }
 
-// === SNIPPET DECLARATIONS ===
-function __svelte_snippet_params_content(
-    { x, y }: Props,
-) {}
-const content: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_content>> = null as any;
-
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     interface Props {
         x: number
@@ -174,9 +170,7 @@ const content: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_content
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   function content(__snippet_params_0: any) {
     const { x, y }: Props = __snippet_params_0;
     x;
@@ -184,11 +178,13 @@ async function __svelte_template_check__() {
     return __svelte_snippet_return;
   }
   content({ x: 1, y: 2 });
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_with_const_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_with_const_transform.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -160,11 +161,8 @@ declare module "svelte" {
   ): Exports;
 }
 
-// === SNIPPET DECLARATIONS ===
-function __svelte_snippet_params_example() {}
-const example: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_example>> = null as any;
-
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let key = $state('test');
 
@@ -173,20 +171,20 @@ const example: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_example
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   function example() {
     const result = check(key) ? 'valid' : 'invalid';
     result;
     return __svelte_snippet_return;
   }
   example();
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__special_chars.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__special_chars.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,19 +153,20 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let message = $state("Hello \"world\" with 'quotes' and \n newlines");
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   message;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__spread_rest_props.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__spread_rest_props.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -159,8 +160,10 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+import Button from './Button.svelte';
+async function __svelte_render() {
 
-    import Button from './Button.svelte';
+                                         
 
     let { class: className, variant = 'default', ...rest } = ({} as __SvelteLoosen<{
         class?: string;
@@ -168,9 +171,7 @@ declare module "svelte" {
     } & Record<string, unknown>>);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   { const __component_0 = __svelte_ensure_component(Button); __component_0(__svelte_any(), {
     class: className,
     variant,
@@ -179,15 +180,17 @@ async function __svelte_template_check__() {
       return __svelte_snippet_return;
     },
   }); }
+return { props: null as any as __SvelteOptionalProps<{
+        class?: string;
+        variant?: 'default' | 'outline' | 'ghost';
+    } & Record<string, unknown>, "variant">, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<__SvelteOptionalProps<{
-        class?: string;
-        variant?: 'default' | 'outline' | 'ghost';
-    } & Record<string, unknown>, "variant">>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 8 ===
+=== Source Map Mappings: 9 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__state_raw_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__state_raw_rune.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,19 +153,20 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let items = $state.raw([1, 2, 3]);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   items.length;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__state_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__state_rune.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -154,22 +155,23 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let count = $state(0);
     let name = $state("hello");
     let data = $state({ x: 1, y: 2 });
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   count;
   name;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__store_in_script_function.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__store_in_script_function.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -157,9 +158,11 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
-    declare let $formData: __StoreValue<typeof formData>;
+import { formStore } from './stores';
+async function __svelte_render() {
+    let $formData!: __StoreValue<typeof formData>;
 
-    import { formStore } from './stores';
+                                         
     const { form: formData } = formStore;
 
     function updateEndTime() {
@@ -167,18 +170,18 @@ declare module "svelte" {
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("button", {}, {
     onclick: () => updateEndTime(),
   });
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
-=== Source Map Mappings: 3 ===
+=== Source Map Mappings: 4 ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_css_custom_property.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_css_custom_property.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 60
 expression: output
 ---
 === Source ===
@@ -156,35 +157,36 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let compensate = $state(0);
     let theme = $state('dark');
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   compensate === 0 ? null : `${compensate}px`;
   __svelte_create_element("path", {}, {
     d: "",
   });
   theme;
   "8px";
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
 === Source Map Mappings (9) ===
-  0: generated 5963..5985 -> original 18..40
-  1: generated 5985..5994 -> original 40..49
-  2: generated 5994..6012 -> original 49..67
-  3: generated 6012..6026 -> original 67..81
-  4: generated 6026..6028 -> original 81..83
-  5: generated 6159..6202 -> original 124..167
-  6: generated 6248..6249 -> original 180..181
-  7: generated 6263..6268 -> original 214..219
-  8: generated 6272..6277 -> original 238..241
+  0: generated 5998..6020 -> original 18..40
+  1: generated 6020..6029 -> original 40..49
+  2: generated 6029..6047 -> original 49..67
+  3: generated 6047..6061 -> original 67..81
+  4: generated 6061..6063 -> original 81..83
+  5: generated 6098..6141 -> original 124..167
+  6: generated 6187..6188 -> original 180..181
+  7: generated 6202..6207 -> original 214..219
+  8: generated 6211..6216 -> original 238..241

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_expression.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_expression.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -153,21 +154,22 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let myColor = $state('red');
     let width = $state(100);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   myColor;
   `${width}px`;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_important.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_important.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,20 +153,21 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let color = $state('red');
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   "red";
   color;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_multiple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_multiple.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -160,22 +161,23 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let darkMode = $state(false);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   "12rem";
   darkMode ? 'black' : 'white';
   "blue";
   darkMode ? 0.8 : 1;
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_shorthand.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_shorthand.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -153,14 +154,18 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let color = $state('red');
     let opacity = $state(0.5);
 
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
+}
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_with_attr.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_with_attr.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,23 +153,24 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let color = $state('red');
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("div", {}, {
     style: "font-size: 16px",
   });
   color;
   "8px";
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_await_block.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_await_block.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -158,13 +159,12 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let promise = fetch('/api/data').then(r => r.json());
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __await_0 = promise;
   {
     // pending
@@ -180,11 +180,13 @@ async function __svelte_template_check__() {
     const error: unknown = __svelte_catch_error(__await_0);
     error.message;
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_each_block.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_each_block.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -154,24 +155,25 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let items = $state([{ id: 1, name: 'a' }, { id: 2, name: 'b' }]);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __each_0 = items;
   for (const [index, item] of __svelte_each_indexed(__each_0)) {
     item.id;
     index;
     item.name;
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_each_else.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_each_else.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -156,24 +157,25 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let items: string[] = $state([]);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __each_0 = items;
   for (const item of __each_0) {
     item;
   }
   if (__svelte_is_empty(__each_0)) {
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_expression.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_expression.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -153,20 +154,21 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let message = "Hello";
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   message;
   message.toUpperCase();
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_if_block.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_if_block.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -159,24 +160,25 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let show = $state(true);
     let user: { name: string } | null = $state(null);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   if (show) {
   }
   if (user) {
     user.name;
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_if_else.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_if_else.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -158,22 +159,23 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let status: 'loading' | 'ready' | 'error' = $state('loading');
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   if (status === 'loading') {
   } else if (status === 'error') {
   } else {
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_snippet.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_snippet.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -159,18 +160,13 @@ declare module "svelte" {
   ): Exports;
 }
 
-// === SNIPPET DECLARATIONS ===
-function __svelte_snippet_params_item(text: string) {}
-const item: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_item>> = null as any;
-
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let items = $state(['a', 'b', 'c']);
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   function item(text: string) {
     text;
     return __svelte_snippet_return;
@@ -179,11 +175,13 @@ async function __svelte_template_check__() {
   for (const i of __each_0) {
     item(i);
   }
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_snippet_generic_header.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_snippet_generic_header.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -152,12 +153,6 @@ declare module "svelte" {
     }
   ): Exports;
 }
-
-// === SNIPPET DECLARATIONS ===
-function __svelte_snippet_params_relationshipFormFields<
-  T extends { relationshipType: string; shortName?: string | undefined },
->(args: T) {}
-const relationshipFormFields: __SvelteSnippet<Parameters<typeof __svelte_snippet_params_relationshipFormFields>> = null as any;
 
 
 // === TEMPLATE TYPE-CHECK BLOCK ===

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_basic.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_basic.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -154,21 +155,22 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     function tooltip(node: HTMLElement) {
         return { destroy() {} };
     }
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __action_attrs_0 = __svelte_ensure_action(tooltip(null as unknown as ElementTagNameMap["div"]));
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_deep_member_access.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_deep_member_access.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -160,6 +161,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     const lib = {
         ui: {
@@ -172,15 +174,15 @@ declare module "svelte" {
     };
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __action_attrs_0 = __svelte_ensure_action(lib.ui.actions.draggable(null as unknown as ElementTagNameMap["div"]));
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -158,6 +159,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     const formSelect = {
         enhance: (node: HTMLFormElement) => {
@@ -166,9 +168,7 @@ declare module "svelte" {
     };
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __action_attrs_0 = __svelte_ensure_action(formSelect.enhance(null as unknown as ElementTagNameMap["form"]));
   __svelte_create_element("form", __action_attrs_0, {
     method: "POST",
@@ -177,11 +177,13 @@ async function __svelte_template_check__() {
   __svelte_create_element("button", {}, {
     type: "submit",
   });
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access_with_parameter.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access_with_parameter.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -159,6 +160,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     const actions = {
         tooltip: {
@@ -170,15 +172,15 @@ declare module "svelte" {
     let options = $state({ content: "Tooltip text" });
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __action_attrs_0 = __svelte_ensure_action(actions.tooltip.show(null as unknown as ElementTagNameMap["div"], options));
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_multiple_with_member_access.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_multiple_with_member_access.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -160,6 +161,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     function tooltip(node: HTMLElement) {
         return { destroy() {} };
@@ -172,17 +174,17 @@ declare module "svelte" {
     let opts = $state({});
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __action_attrs_0 = __svelte_ensure_action(tooltip(null as unknown as ElementTagNameMap["div"]));
   const __action_attrs_1 = __svelte_ensure_action(draggable.handle(null as unknown as ElementTagNameMap["div"]));
   const __action_attrs_2 = __svelte_ensure_action(tooltip(null as unknown as ElementTagNameMap["div"], opts));
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_source_mapping.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_source_mapping.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 60
 expression: output
 ---
 === Source ===
@@ -158,6 +159,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     const form = {
         enhance: (node: HTMLFormElement) => {
@@ -166,18 +168,18 @@ declare module "svelte" {
     };
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __action_attrs_0 = __svelte_ensure_action(form.enhance(null as unknown as ElementTagNameMap["form"]));
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 
 === Source Map Mappings (2) ===
-  0: generated 5963..6083 -> original 18..138
-  1: generated 6262..6274 -> original 159..171
+  0: generated 5998..6118 -> original 18..138
+  1: generated 6201..6213 -> original 159..171

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_with_parameter.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_with_parameter.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -155,6 +156,7 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     function tooltip(node: HTMLElement, content: string) {
         return { destroy() {} };
@@ -162,15 +164,15 @@ declare module "svelte" {
     let content = $state("Hello");
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   const __action_attrs_0 = __svelte_ensure_action(tooltip(null as unknown as ElementTagNameMap["div"], content));
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__xmlns_xlink_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__xmlns_xlink_transform.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/svelte-transformer/tests/snapshots.rs
+assertion_line: 25
 expression: output
 ---
 === Source ===
@@ -154,13 +155,12 @@ declare module "svelte" {
 }
 
 // === INSTANCE SCRIPT ===
+async function __svelte_render() {
 
     let className = '';
 
 
-// === TEMPLATE TYPE-CHECK BLOCK ===
-// This is never executed, just type-checked
-async function __svelte_template_check__() {
+// === TEMPLATE TYPE-CHECK ===
   __svelte_create_element("svg", {}, {
     class: className,
     xmlns: "http://www.w3.org/2000/svg",
@@ -170,11 +170,13 @@ async function __svelte_template_check__() {
     width: "100",
     height: "100",
   });
+return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 
 // === COMPONENT TYPE EXPORT ===
-type __SvelteProps_Test_ = __SvelteLoosen<{}>;
-declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
+type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
+declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-93-snippet-export/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-93-snippet-export/+page.svelte
@@ -1,0 +1,18 @@
+<script module lang="ts">
+  export type Row = {
+    id: string;
+    label: string;
+  };
+
+  export { rowCell };
+</script>
+
+<script lang="ts">
+  const row: Row = { id: "1", label: "Row 1" };
+</script>
+
+{#snippet rowCell(item: Row)}
+  <span>{item.label}</span>
+{/snippet}
+
+{@render rowCell(row)}

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-93-snippet-instance-typeof/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-93-snippet-instance-typeof/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  const items = [{ id: "a", label: "A" }];
+</script>
+
+{#snippet itemCell(item: (typeof items)[number])}
+  {item.label}
+{/snippet}
+
+{@render itemCell(items[0])}

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-93-store-alias/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-93-store-alias/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import { writable } from 'svelte/store';
+
+  const form = { form: writable({ value: 1 }) };
+  const { form: formData } = form;
+</script>
+
+<p>{$formData.value}</p>

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-93-type-narrowing-guard/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-93-type-narrowing-guard/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  // Issue #93 variant: Type narrowing with type guards
+  // This tests that type guard functions work correctly
+
+  type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+  function isOk<T>(result: Result<T>): result is { ok: true; value: T } {
+    return result.ok;
+  }
+
+  // Use a function to get result so TypeScript can't statically narrow it
+  function getResult(): Result<string> {
+    return Math.random() > 0.5
+      ? { ok: true, value: "Hello" }
+      : { ok: false, error: "Failed" };
+  }
+
+  const result = getResult();
+
+  // Type narrowing via type guard
+  if (!isOk(result)) {
+    throw new Error(result.error);
+  }
+
+  // After guard, result should be { ok: true; value: string }
+  const message = result.value;
+</script>
+
+<!-- Template should see result.value as string -->
+<p>{result.value}</p>
+<p>Message: {message}</p>

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-93-type-narrowing-return/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-93-type-narrowing-return/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  // Issue #93 variant: Type narrowing after early return
+  // This tests that control flow analysis works for return statements too
+
+  interface User {
+    name: string;
+    email: string;
+  }
+
+  let { data } = $props<{ data: { user: User | null } }>();
+
+  // Type narrowing via early return - after this, data.user should be User
+  if (!data.user) {
+    // In a real component, this might redirect or show loading state
+    // For testing, we just need to ensure the narrowing is recognized
+  }
+
+  // Only access user properties after the guard
+  const userName = data.user ? data.user.name : "Guest";
+</script>
+
+<!-- Test direct narrowing in template with if block -->
+{#if data.user}
+  <p>Welcome, {data.user.name}!</p>
+  <p>Email: {data.user.email}</p>
+{/if}

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-93-type-narrowing-throw/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-93-type-narrowing-throw/+page.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  // Issue #93: Type narrowing after throw should be recognized in template
+  // https://github.com/pheuter/svelte-check-rs/issues/93
+
+  interface DataFile {
+    figshare: string;
+    name: string;
+  }
+
+  const data_files: Record<string, DataFile | undefined> = {
+    mp_trj_json_gz: { figshare: "https://example.com/data", name: "trajectory" }
+  };
+
+  const mp_trj_data = data_files["mp_trj_json_gz"];
+
+  // Type narrowing via throw - after this, mp_trj_data should be DataFile
+  if (!mp_trj_data) {
+    throw new Error("mp_trj_json_gz not found");
+  }
+
+  // At this point, mp_trj_data is narrowed to DataFile (not undefined)
+</script>
+
+<!-- Template should see mp_trj_data as DataFile, not DataFile | undefined -->
+<a href={mp_trj_data.figshare}>{mp_trj_data.name}</a>


### PR DESCRIPTION
## Summary

Fixes #93 - Type narrowing not recognized after throw statement.

- Wrap script and template code in a shared `__svelte_render()` function scope
- TypeScript's control flow analysis now propagates narrowing from script to template
- Patterns like `if (!x) throw ...` now correctly narrow types in template expressions

## Details

Previously, the template was generated as a separate `__svelte_template_check__()` function, which broke TypeScript's control flow analysis since it only works within a single scope.

**Before:** Template isolated from script narrowing
```typescript
// Script runs here, narrowing x
async function __svelte_template_check__() {
  // Template can't see narrowing from script
  x.property; // Error: possibly undefined
}
```

**After:** Template embedded in render function
```typescript
async function __svelte_render() {
  if (!x) throw new Error();
  // Narrowing visible to template below
  x.property; // OK: x is narrowed
}
```

## Test Coverage

Added 6 integration test cases:

| Test | Scenario |
|------|----------|
| `type-narrowing-throw` | Core issue: `if (!x) throw` narrows in template |
| `type-narrowing-guard` | Type predicate functions (`x is T`) |
| `type-narrowing-return` | Template `{#if}` block narrowing |
| `store-alias` | Store alias scope isolation |
| `snippet-export` | Module script snippet exports |
| `snippet-instance-typeof` | Snippet instance-only type references |

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR successfully fixes issue #93 by preserving TypeScript's control flow analysis for type narrowing between script and template sections.

**Key Changes:**
- Unified script and template code within a shared `async function __svelte_render()` scope
- TypeScript's control flow narrowing (e.g., `if (!x) throw ...`) now propagates from script to template
- Store aliases changed from `declare let` to `let ... !:` syntax inside the render function
- Import statements are now properly extracted and hoisted with AST parsing (using SWC) instead of regex
- Export values are now built as runtime objects instead of relying on string concatenation

**Implementation Details:**
- Added `generate_template_body_with_spans()` to emit template code without a function wrapper
- Both generic and non-generic components now use the render function approach
- Component type exports now use `Awaited<ReturnType<typeof __svelte_render>>` to extract props and exports
- Module-exported snippets are correctly filtered and declared outside the render function

**Test Coverage:**
The PR includes 6 integration tests covering:
- Type narrowing after throw statements
- Type guard functions
- Template if-block narrowing  
- Store alias scope isolation
- Module script snippet exports
- Instance-only type references in snippets

All 84 snapshot tests were updated to reflect the new transformation structure.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with high confidence - well-tested architectural improvement
- Comprehensive test coverage with 6 new integration tests, all 84 snapshots updated correctly, and the change addresses a fundamental TypeScript control flow issue with a clean architectural solution
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/svelte-transformer/src/transform.rs | Unified script and template in `__svelte_render()` function to preserve TypeScript control flow narrowing |
| crates/svelte-transformer/src/template.rs | Added `generate_template_body_with_spans()` to emit template code without function wrapper |
| crates/svelte-check-rs/tests/integration_issues.rs | Added comprehensive integration tests for issue #93 type narrowing scenarios |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->