### PR TITLE
refactor(bun): use official install script instead of npm/pnpm/yarn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,6 +2174,7 @@ name = "tsgo-runner"
 version = "0.8.0"
 dependencies = [
  "blake3",
+ "bun-runner",
  "camino",
  "dirs",
  "pretty_assertions",

--- a/crates/svelte-check-rs/src/main.rs
+++ b/crates/svelte-check-rs/src/main.rs
@@ -10,7 +10,7 @@ use camino::Utf8Path;
 use clap::Parser;
 use cli::Args;
 use miette::Result;
-use tsgo_runner::{PackageManager, TsgoRunner};
+use tsgo_runner::TsgoRunner;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -110,23 +110,6 @@ fn print_debug_paths(workspace: &Utf8Path) {
     };
 
     println!("Workspace: {}", workspace);
-    println!();
-
-    // Package manager detection
-    println!("Package Manager:");
-    if let Some(pm) = PackageManager::detect_from_workspace(&workspace) {
-        println!(
-            "  from workspace: {} (detected from lockfile)",
-            pm.command_name()
-        );
-    } else {
-        println!("  from workspace: (none detected)");
-    }
-    if let Some(pm) = PackageManager::detect_from_path() {
-        println!("  from PATH:      {}", pm.command_name());
-    } else {
-        println!("  from PATH:      (none found)");
-    }
     println!();
 
     // tsgo binary

--- a/crates/tsgo-runner/Cargo.toml
+++ b/crates/tsgo-runner/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 description = "tsgo process runner for TypeScript type-checking"
 
 [dependencies]
+bun-runner.workspace = true
 source-map.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/tsgo-runner/src/lib.rs
+++ b/crates/tsgo-runner/src/lib.rs
@@ -37,6 +37,6 @@ mod runner;
 
 pub use parser::{DiagnosticSeverity, TsgoDiagnostic, TsgoOutput};
 pub use runner::{
-    PackageManager, TransformedFile, TransformedFiles, TsgoCacheStats, TsgoCheckOutput,
-    TsgoCheckStats, TsgoError, TsgoRunner, TsgoTimingStats,
+    TransformedFile, TransformedFiles, TsgoCacheStats, TsgoCheckOutput, TsgoCheckStats, TsgoError,
+    TsgoRunner, TsgoTimingStats,
 };


### PR DESCRIPTION
## Summary

Remove dependency on Node.js package managers for bootstrapping bun. Now uses the official bun.sh install script directly.

## Details

- **Unix**: `curl -fsSL https://bun.sh/install | bash`
- **Windows**: `powershell -c "irm bun.sh/install.ps1 | iex"`

### Changes

- Remove `PackageManager` enum from both `bun-runner` and `tsgo-runner` crates
- Remove `BunError::PackageManagerNotFound` and `TsgoError::PackageManagerNotFound`
- Add `~/.bun/bin/bun` to the bun search path (default install location)
- Rewrite `ensure_bun()` and `update_bun()` to use the official install script
- Update `tsgo-runner` to depend on `bun-runner` for bun installation
- Remove package manager detection from `--debug-paths` output

### Benefits

- Zero Node.js dependency for bootstrapping
- Simpler installation flow
- Cross-platform support (Unix + Windows)
- ~130 fewer lines of code

## Testing

Manually tested by removing `~/.bun` and running the CLI - bun auto-installs via the script and subsequent runs skip installation.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR successfully removes the Node.js package manager dependency for bootstrapping bun by using the official bun.sh install script directly. The refactoring removes ~130 lines of code related to package manager detection and simplifies the installation flow.

**Key changes:**
- Replaced package manager-based installation with official bun.sh install script (`curl | bash` on Unix, `irm | iex` on Windows)
- Added `~/.bun/bin/bun` to the bun search path as the default install location
- Removed `PackageManager` enum from both `bun-runner` and `tsgo-runner` crates
- Updated `tsgo-runner` to depend on `bun-runner` for bun installation
- Removed package manager detection from `--debug-paths` CLI output

**Issues found:**
- Minor: Outdated comment in `crates/tsgo-runner/src/runner.rs:810` references old npm/pnpm/yarn installation method

The implementation follows bun's official installation approach and maintains cross-platform compatibility. The change simplifies the codebase while achieving the stated goal of zero Node.js dependency for bootstrapping.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor documentation issue
- The refactoring is well-executed with clean removal of package manager code and proper replacement with official install scripts. One outdated comment needs fixing but doesn't affect functionality. The approach follows bun's official installation method.
- crates/tsgo-runner/src/runner.rs (outdated comment)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/bun-runner/src/runner.rs | Replaced package manager-based bun installation with official bun.sh install script; added `~/.bun/bin` to search path; removed `PackageManager` enum |
| crates/tsgo-runner/src/runner.rs | Replaced package manager-based tsgo installation with bun; removed `PackageManager` enum; outdated comment references old installation method |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->