### PR TITLE
fix(bun,tsgo): add file locking for concurrent installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
  "blake3",
  "camino",
  "dirs",
+ "fs2",
  "serde",
  "serde_json",
  "thiserror",
@@ -560,6 +561,16 @@ checksum = "e5ff35a391aef949120a0340d690269b3d9f63460a6106e99bd07b961f345ea9"
 dependencies = [
  "swc_macros_common",
  "syn",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2177,6 +2188,7 @@ dependencies = [
  "bun-runner",
  "camino",
  "dirs",
+ "fs2",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -2363,6 +2375,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,6 +2398,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ insta = { version = "1.40", features = ["json", "redactions"] }
 pretty_assertions = "1.4"
 
 # Utilities
+fs2 = "0.4"
 indexmap = { version = "2.6", features = ["serde"] }
 rustc-hash = "2.0"
 smol_str = "0.3"

--- a/crates/bun-runner/Cargo.toml
+++ b/crates/bun-runner/Cargo.toml
@@ -8,6 +8,7 @@ description = "Persistent bun runner for Svelte compiler diagnostics"
 
 [dependencies]
 camino.workspace = true
+fs2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/tsgo-runner/Cargo.toml
+++ b/crates/tsgo-runner/Cargo.toml
@@ -8,6 +8,7 @@ description = "tsgo process runner for TypeScript type-checking"
 
 [dependencies]
 bun-runner.workspace = true
+fs2.workspace = true
 source-map.workspace = true
 thiserror.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
## Summary

Adds file-based locking to prevent race conditions when multiple `svelte-check-rs` processes attempt to install bun or tsgo simultaneously (e.g., in monorepo scenarios with parallel builds).

## Details

- Uses `fs2` crate for cross-platform exclusive file locking
- Implements double-checked locking pattern: check if installed, acquire lock, check again (another process may have installed while waiting)
- Lock files:
  - `~/.bun/.install.lock` for bun installation
  - `~/.cache/svelte-check-rs/.tsgo-install.lock` for tsgo installation

## Testing

- `cargo test` - all tests pass
- `cargo clippy --all-targets -- -D warnings` - no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds file-based exclusive locking using the `fs2` crate to prevent race conditions during concurrent bun and tsgo installations in monorepo scenarios with parallel builds.

**Key Changes:**
- `bun-runner`: Lock file at `~/.bun/.install.lock` with double-checked locking in `install_bun_via_script`
- `tsgo-runner`: Lock file at `~/.cache/svelte-check-rs/.tsgo-install.lock` in both `update_tsgo` and `ensure_tsgo`
- Locks are automatically released via RAII when the `File` handle goes out of scope

**Implementation:**
- Uses cross-platform `FileExt::lock_exclusive()` from `fs2` crate
- Double-checked locking pattern in `install_bun_via_script` and `ensure_tsgo` prevents redundant work
- `update_tsgo` missing the double-check after acquiring lock

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor improvement recommended - file locking implementation is sound but one function is missing the double-check optimization
- The file locking implementation correctly uses exclusive locks and RAII for automatic cleanup. The double-checked locking pattern in `install_bun_via_script` and `ensure_tsgo` is correct. However, `update_tsgo` is missing the double-check after acquiring the lock, which could lead to redundant installations when multiple processes call update simultaneously
- crates/tsgo-runner/src/runner.rs - `update_tsgo` function missing double-check after lock acquisition

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/bun-runner/src/runner.rs | Implemented file locking in `install_bun_via_script` to prevent concurrent bun installations |
| crates/tsgo-runner/src/runner.rs | Implemented file locking in `update_tsgo` and `ensure_tsgo` to prevent concurrent tsgo installations |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->