### PR TITLE
fix(parser): support use:action(args) shorthand syntax

### DIFF
--- a/crates/svelte-parser/src/parser.rs
+++ b/crates/svelte-parser/src/parser.rs
@@ -1649,6 +1649,25 @@ impl<'src> Parser<'src> {
                 } else {
                     None
                 }
+            } else if self.check(TokenKind::LParen) {
+                // use:action(args) shorthand — Svelte allows `use:action(args)` as
+                // an alternative to `use:action={args}`. Read the parenthesized
+                // expression and treat it as the directive value.
+                let paren_start = self.current().span.start;
+                self.advance(); // consume '('
+                let (expr, expr_span) = self.read_expression_until(')');
+                self.eat(TokenKind::RParen);
+                let end = self
+                    .tokens
+                    .get(self.pos.saturating_sub(1))
+                    .map(|t| t.span.end)
+                    .unwrap_or(paren_start);
+                Some(ExpressionValue {
+                    span: Span::new(paren_start, end),
+                    expression_span: expr_span,
+                    expression: expr,
+                    is_quoted: false,
+                })
             } else {
                 None
             };

--- a/crates/svelte-parser/tests/snapshots.rs
+++ b/crates/svelte-parser/tests/snapshots.rs
@@ -321,6 +321,26 @@ fn test_snapshot_use_directive_with_modifiers() {
     );
 }
 
+// === use:action(args) shorthand syntax ===
+
+#[test]
+fn test_snapshot_use_directive_paren_args() {
+    // use:action(args) shorthand — equivalent to use:action={args}
+    parse_snapshot(
+        "use_directive_paren_args",
+        r#"<img use:handleMount(file) alt="test" />"#,
+    );
+}
+
+#[test]
+fn test_snapshot_use_directive_paren_args_complex() {
+    // use:action(complex_expression) with a nested call
+    parse_snapshot(
+        "use_directive_paren_args_complex",
+        r#"<div use:tooltip(getText('hello')) class="box"></div>"#,
+    );
+}
+
 // === Issue #40: XML Namespace Attributes ===
 
 #[test]

--- a/crates/svelte-parser/tests/snapshots/snapshots__use_directive_paren_args.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__use_directive_paren_args.snap
@@ -1,0 +1,84 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+<img use:handleMount(file) alt="test" />
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            Element(
+                Element {
+                    span: Span {
+                        start: 0,
+                        end: 40,
+                    },
+                    name: "img",
+                    attributes: [
+                        Directive(
+                            Directive {
+                                span: Span {
+                                    start: 5,
+                                    end: 26,
+                                },
+                                kind: Use,
+                                name: "handleMount",
+                                modifiers: [],
+                                expression: Some(
+                                    ExpressionValue {
+                                        span: Span {
+                                            start: 20,
+                                            end: 26,
+                                        },
+                                        expression_span: Span {
+                                            start: 21,
+                                            end: 25,
+                                        },
+                                        expression: "file",
+                                        is_quoted: false,
+                                    },
+                                ),
+                            },
+                        ),
+                        Normal(
+                            NormalAttribute {
+                                span: Span {
+                                    start: 27,
+                                    end: 37,
+                                },
+                                name: "alt",
+                                value: Text(
+                                    TextValue {
+                                        span: Span {
+                                            start: 32,
+                                            end: 36,
+                                        },
+                                        value: "test",
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                    children: [],
+                    self_closing: true,
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 40,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 40,
+    },
+}

--- a/crates/svelte-parser/tests/snapshots/snapshots__use_directive_paren_args_complex.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__use_directive_paren_args_complex.snap
@@ -1,0 +1,84 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+<div use:tooltip(getText('hello')) class="box"></div>
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            Element(
+                Element {
+                    span: Span {
+                        start: 0,
+                        end: 53,
+                    },
+                    name: "div",
+                    attributes: [
+                        Directive(
+                            Directive {
+                                span: Span {
+                                    start: 5,
+                                    end: 34,
+                                },
+                                kind: Use,
+                                name: "tooltip",
+                                modifiers: [],
+                                expression: Some(
+                                    ExpressionValue {
+                                        span: Span {
+                                            start: 16,
+                                            end: 34,
+                                        },
+                                        expression_span: Span {
+                                            start: 17,
+                                            end: 33,
+                                        },
+                                        expression: "getText('hello')",
+                                        is_quoted: false,
+                                    },
+                                ),
+                            },
+                        ),
+                        Normal(
+                            NormalAttribute {
+                                span: Span {
+                                    start: 35,
+                                    end: 46,
+                                },
+                                name: "class",
+                                value: Text(
+                                    TextValue {
+                                        span: Span {
+                                            start: 42,
+                                            end: 45,
+                                        },
+                                        value: "box",
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                    children: [],
+                    self_closing: false,
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 53,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 53,
+    },
+}

--- a/test-fixtures/valid/parser/UseDirectiveWithArgs.svelte
+++ b/test-fixtures/valid/parser/UseDirectiveWithArgs.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	function handleMount(node: HTMLElement, file: { name: string }) {
+		return { destroy() {} };
+	}
+
+	let file = { name: 'test.png' };
+</script>
+
+<!-- use:action(args) shorthand syntax — equivalent to use:action={args} -->
+<img use:handleMount(file) alt="test" />


### PR DESCRIPTION
Closes #107

## Summary

- Svelte allows `use:action(args)` as shorthand for `use:action={args}`, but the parser only handled the `={expr}` form
- When `(` was encountered after the action name, it was left in the token stream and caused: `unexpected token: expected '>', found '('`
- Fix: after reading a directive name, if the next token is `(`, read the parenthesised expression and store it as the directive value

## Details

The `parse_attribute` function in `crates/svelte-parser/src/parser.rs` now has an `else if self.check(TokenKind::LParen)` branch alongside the existing `else if self.eat(TokenKind::Eq)` branch. The parenthesised content is read with `read_expression_until(')')`, which already handles nested parens and string literals correctly, so `use:action(fn('x'))` works too.

## Why

Encountered in real Svelte 5 codebases using e.g.:
```svelte
<img use:handleImageMount(file) />
```

## Testing

- Added `test-fixtures/valid/parser/UseDirectiveWithArgs.svelte` (picked up automatically by corpus tests)
- Added two parser snapshots: simple arg form and nested-call arg form
- All 141 unit + 11 corpus + 58 snapshot tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)