### PR TITLE
fix(parser): correct escape detection for strings ending with \\

### DIFF
--- a/crates/svelte-parser/tests/snapshots.rs
+++ b/crates/svelte-parser/tests/snapshots.rs
@@ -321,6 +321,18 @@ fn test_snapshot_use_directive_with_modifiers() {
     );
 }
 
+// === Escape sequences in attribute expressions ===
+
+#[test]
+fn test_snapshot_expression_double_backslash_string() {
+    // String ending with \\ before closing quote — naive lookbehind incorrectly treats
+    // the closing quote as escaped.
+    parse_snapshot(
+        "expression_double_backslash_string",
+        r#"<button onclick={() => open('C:\\Users\\')}>Open</button>"#,
+    );
+}
+
 // === Issue #40: XML Namespace Attributes ===
 
 #[test]

--- a/crates/svelte-parser/tests/snapshots/snapshots__expression_double_backslash_string.snap
+++ b/crates/svelte-parser/tests/snapshots/snapshots__expression_double_backslash_string.snap
@@ -1,0 +1,75 @@
+---
+source: crates/svelte-parser/tests/snapshots.rs
+assertion_line: 9
+expression: output
+---
+Source:
+<button onclick={() => open('C:\\Users\\')}>Open</button>
+
+Errors: []
+
+AST:
+SvelteDocument {
+    module_script: None,
+    instance_script: None,
+    style: None,
+    fragment: Fragment {
+        nodes: [
+            Element(
+                Element {
+                    span: Span {
+                        start: 0,
+                        end: 57,
+                    },
+                    name: "button",
+                    attributes: [
+                        Normal(
+                            NormalAttribute {
+                                span: Span {
+                                    start: 8,
+                                    end: 43,
+                                },
+                                name: "onclick",
+                                value: Expression(
+                                    ExpressionValue {
+                                        span: Span {
+                                            start: 16,
+                                            end: 43,
+                                        },
+                                        expression_span: Span {
+                                            start: 17,
+                                            end: 42,
+                                        },
+                                        expression: "() => open('C:\\\\Users\\\\')",
+                                        is_quoted: false,
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                    children: [
+                        Text(
+                            Text {
+                                span: Span {
+                                    start: 44,
+                                    end: 48,
+                                },
+                                data: "Open",
+                                is_whitespace: false,
+                            },
+                        ),
+                    ],
+                    self_closing: false,
+                },
+            ),
+        ],
+        span: Span {
+            start: 0,
+            end: 57,
+        },
+    },
+    span: Span {
+        start: 0,
+        end: 57,
+    },
+}

--- a/test-fixtures/valid/parser/ExpressionEscapeBackslash.svelte
+++ b/test-fixtures/valid/parser/ExpressionEscapeBackslash.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	function open(path: string) {}
+</script>
+
+<!-- String ending with \\ before closing quote; the naive single-char lookbehind
+     incorrectly treats the closing quote as escaped -->
+<button onclick={() => open('C:\\Users\\')}>Open</button>
+
+<!-- Deeper nesting: UNC-style path ending with \\ -->
+<button onclick={() => open('\\\\Server\\Share\\')}>UNC</button>


### PR DESCRIPTION
Closes #108

## Summary

- The expression parser used a naive single-character lookbehind (`bytes[pos-1] == '\'`) to detect escaped characters inside strings
- This fails for `'\'` (a string ending with an escaped backslash): the closing quote has `\` as its preceding byte, so it is incorrectly treated as escaped
- The parser then consumes the rest of the file as string content, causing cascading unclosed-tag errors

## Details

**Root cause** — in `read_expression_until` and several helper functions, the escape check was:
```rust
let is_escaped = absolute_i > 0 && bytes.get(absolute_i - 1) == Some(&b'\');
```
For source like `'\\NAS\Templates\'`, the final `'` has a `\` predecessor, so `is_escaped` is `true` even though both preceding backslashes form an escaped backslash (`\`), not an escape for the quote.

**Fix** — replace with a consecutive-backslash count; an *odd* count means the character is escaped, an *even* count means the backslashes are paired:
```rust
let preceding_backslashes = (0..absolute_i)
    .rev()
    .take_while(|&j| bytes.get(j) == Some(&b'\'))
    .count();
let is_escaped = preceding_backslashes % 2 == 1;
```
Applied to all six string-closing checks across `read_expression_until`, `read_expression_from_offset`, `find_keyword_in_expr`, `find_as_keyword_in_expr`, `find_char_in_expr`, and the inline brace-scanning loop.

## Why

Encountered in a real component containing a Windows UNC path attribute:
```svelte
<FieldInput
  onRightIconClick={() =>
    launchCustomProtocol('metroid', '\\NAS\Scripts\Templates\' + path)}
/>
```
This produced spurious errors: `unclosed tag: <FieldInput>`, `unclosed tag: <div>`, `unclosed tag: <Dialog>` — all pointing at EOF.

## Testing

- Added `test-fixtures/valid/parser/ExpressionEscapeBackslash.svelte` with both `'\'` and `'\\'` cases
- Added parser snapshot `expression_double_backslash_string`
- All 141 unit + 11 corpus + 57 snapshot tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)