### PR TITLE
test(parser): add upstream svelte parser corpus parity harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ cargo clippy --all-targets -- -D warnings
 cargo fmt
 ```
 
+### Upstream parser parity sweep
+
+To compare this parser against Svelte's full parser suites (`parser-modern` + `parser-legacy`),
+run the optional ignored test with a local checkout of `sveltejs/svelte`:
+
+```bash
+git clone https://github.com/sveltejs/svelte.git /tmp/svelte
+SVELTE_REPO=/tmp/svelte cargo test -p svelte-parser test_upstream_svelte_parser_samples -- --ignored
+```
+
+By default, `loose-*` samples are skipped because `svelte-parser` does not expose loose mode.
+Set `SVELTE_INCLUDE_LOOSE=1` to include them.
+
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details.

--- a/crates/svelte-parser/tests/upstream_parser_corpus.rs
+++ b/crates/svelte-parser/tests/upstream_parser_corpus.rs
@@ -1,0 +1,145 @@
+//! Optional parity test against upstream Svelte parser suites.
+//!
+//! This test is intentionally `ignored` because it requires a local checkout
+//! of the Svelte repository and currently serves as a parity-gap detector.
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use svelte_parser::parse;
+
+const SUITES: &[&str] = &["parser-modern", "parser-legacy"];
+
+#[derive(Debug, Clone)]
+struct ParserSample {
+    suite: String,
+    name: String,
+    input_path: PathBuf,
+    loose: bool,
+}
+
+fn collect_samples(svelte_repo: &Path) -> Vec<ParserSample> {
+    let mut samples = Vec::new();
+
+    for suite in SUITES {
+        let samples_dir = svelte_repo
+            .join("packages")
+            .join("svelte")
+            .join("tests")
+            .join(suite)
+            .join("samples");
+
+        let Ok(entries) = fs::read_dir(&samples_dir) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            let sample_dir = entry.path();
+            if !sample_dir.is_dir() {
+                continue;
+            }
+
+            let Some(name_os) = sample_dir.file_name() else {
+                continue;
+            };
+            let name = name_os.to_string_lossy().into_owned();
+            let input_path = sample_dir.join("input.svelte");
+            if !input_path.is_file() {
+                continue;
+            }
+
+            samples.push(ParserSample {
+                suite: (*suite).to_string(),
+                loose: name.starts_with("loose-"),
+                name,
+                input_path,
+            });
+        }
+    }
+
+    samples.sort_by(|a, b| {
+        a.suite
+            .cmp(&b.suite)
+            .then_with(|| a.name.cmp(&b.name))
+            .then_with(|| a.input_path.cmp(&b.input_path))
+    });
+    samples
+}
+
+fn normalize_input(source: String) -> String {
+    source.trim_end().replace('\r', "")
+}
+
+#[test]
+#[ignore = "requires SVELTE_REPO to a local sveltejs/svelte checkout"]
+fn test_upstream_svelte_parser_samples() {
+    let Ok(svelte_repo) = env::var("SVELTE_REPO") else {
+        eprintln!("Skipping upstream parser corpus: set SVELTE_REPO to a sveltejs/svelte checkout");
+        return;
+    };
+
+    let svelte_repo = PathBuf::from(svelte_repo);
+    if !svelte_repo.exists() {
+        panic!("SVELTE_REPO does not exist: {}", svelte_repo.display());
+    }
+
+    let include_loose = env::var("SVELTE_INCLUDE_LOOSE").is_ok_and(|v| v == "1");
+    let samples = collect_samples(&svelte_repo);
+    assert!(
+        !samples.is_empty(),
+        "No parser samples found under {}",
+        svelte_repo.display()
+    );
+
+    let mut failures = Vec::new();
+    let mut checked = 0usize;
+    let mut skipped_loose = 0usize;
+
+    for sample in samples {
+        if sample.loose && !include_loose {
+            skipped_loose += 1;
+            continue;
+        }
+
+        let source = fs::read_to_string(&sample.input_path)
+            .unwrap_or_else(|e| panic!("Failed to read {}: {e}", sample.input_path.display()));
+        let result = parse(&normalize_input(source));
+        checked += 1;
+
+        if !result.errors.is_empty() {
+            failures.push(format!(
+                "{}:{} ({} errors)",
+                sample.suite,
+                sample.name,
+                result.errors.len()
+            ));
+        }
+    }
+
+    eprintln!(
+        "Upstream parser corpus: checked {}, skipped_loose {}, failures {}",
+        checked,
+        skipped_loose,
+        failures.len()
+    );
+
+    if !failures.is_empty() {
+        let preview = failures
+            .iter()
+            .take(50)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n");
+        panic!(
+            "Found {} parser parity gaps.\n{}\n{}",
+            failures.len(),
+            preview,
+            if failures.len() > 50 {
+                "\n(truncated to first 50 failures)"
+            } else {
+                ""
+            }
+        );
+    }
+}


### PR DESCRIPTION
Closes #33 

Summary
  Adds an opt-in upstream parser parity harness so we can run svelte-parser against Svelte’s full parser
  test corpus (parser-modern + parser-legacy) and quickly identify parity gaps.

  Details

  - Added new ignored test: crates/svelte-parser/tests/upstream_parser_corpus.rs
  - Test reads parser samples from a local sveltejs/svelte checkout via SVELTE_REPO
  - Scans:
      - packages/svelte/tests/parser-modern/samples/*/input.svelte
      - packages/svelte/tests/parser-legacy/samples/*/input.svelte
  - Normalizes input similarly to upstream test flow (trim trailing whitespace, strip CRs)
  - Runs svelte_parser::parse on each sample and fails with a concise list of parity gaps
  - Skips loose-* samples by default; supports SVELTE_INCLUDE_LOOSE=1 to include them
  - Added README docs under Development: “Upstream parser parity sweep” with runnable commands

  Why
  Issue #33 asks about reusing upstream parser test cases to reduce long-tail parser bug reports.
  This provides a practical first step: full upstream corpus execution without vendoring thousands of
  fixtures, while keeping CI stable via #[ignore].

  How to run

  git clone https://github.com/sveltejs/svelte.git /tmp/svelte
  SVELTE_REPO=/tmp/svelte cargo test -p svelte-parser test_upstream_svelte_parser_samples -- --ignored
  # include loose fixtures:
  SVELTE_REPO=/tmp/svelte SVELTE_INCLUDE_LOOSE=1 cargo test -p svelte-parser
  test_upstream_svelte_parser_samples -- --ignored

  Observed results on this branch

  - Without loose fixtures: 7 parity gaps (96 checked, 10 loose skipped)
  - With loose fixtures: 14 parity gaps (106 checked)

  This confirms the harness is working and already surfacing concrete parser parity targets.