### PR TITLE
fix(cli): forward experimental.async to Svelte compiler (#121)

### DIFF
--- a/crates/bun-runner/src/lib.rs
+++ b/crates/bun-runner/src/lib.rs
@@ -3,6 +3,6 @@
 mod runner;
 
 pub use runner::{
-    BunCompileOptions, BunDiagnostic, BunDiagnosticSeverity, BunError, BunInput, BunPosition,
-    BunRunner,
+    BunCompileOptions, BunDiagnostic, BunDiagnosticSeverity, BunError, BunExperimentalOptions,
+    BunInput, BunPosition, BunRunner,
 };

--- a/crates/bun-runner/src/runner.rs
+++ b/crates/bun-runner/src/runner.rs
@@ -58,6 +58,10 @@ for await (const line of rl) {
     runes: options.runes
   };
 
+  if (options.experimental != null && typeof options.experimental === 'object') {
+    compileOptions.experimental = options.experimental;
+  }
+
   let diagnostics = [];
 
   try {
@@ -117,6 +121,14 @@ pub enum BunError {
     ParseError(String),
 }
 
+/// Subset of Svelte `compile()` options under `experimental`.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct BunExperimentalOptions {
+    /// `experimental.async` — enables `await` in components when `true`.
+    #[serde(rename = "async", skip_serializing_if = "Option::is_none")]
+    pub async_: Option<bool>,
+}
+
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct BunCompileOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -125,6 +137,8 @@ pub struct BunCompileOptions {
     pub dev: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub generate: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<BunExperimentalOptions>,
 }
 
 #[derive(Debug, Clone)]
@@ -659,5 +673,6 @@ mod tests {
     fn test_bun_compile_options_default() {
         let options = BunCompileOptions::default();
         assert!(options.runes.is_none());
+        assert!(options.experimental.is_none());
     }
 }

--- a/crates/svelte-check-rs/src/config.rs
+++ b/crates/svelte-check-rs/src/config.rs
@@ -7,8 +7,8 @@ use std::fs;
 use std::sync::Arc;
 use swc_common::SourceMap;
 use swc_ecma_ast::{
-    ExportDefaultExpr, Expr, KeyValueProp, Lit, ModuleDecl, ModuleItem, ObjectLit, Prop, PropName,
-    PropOrSpread,
+    Decl, ExportDefaultExpr, Expr, KeyValueProp, Lit, ModuleDecl, ModuleItem, ObjectLit, Pat, Prop,
+    PropName, PropOrSpread, Stmt, VarDeclKind,
 };
 use swc_ecma_parser::{parse_file_as_module, EsSyntax, Syntax, TsSyntax};
 
@@ -81,6 +81,9 @@ pub struct KitConfig {
 pub struct SvelteCompilerOptions {
     /// Enable runes mode.
     pub runes: Option<bool>,
+
+    /// `compilerOptions.experimental.async` from `svelte.config.js`.
+    pub experimental_async: Option<bool>,
 }
 
 impl SvelteConfig {
@@ -139,20 +142,51 @@ impl SvelteConfig {
 
         let mut config = SvelteConfig::default();
 
-        // Find the default export
+        let object_by_name = Self::collect_top_level_object_consts(&module.body);
+
+        // Find the default export (`export default { ... }` or `export default config`)
         for item in &module.body {
             if let ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(ExportDefaultExpr {
                 expr,
                 ..
             })) = item
             {
-                if let Expr::Object(obj) = expr.as_ref() {
+                let root = match expr.as_ref() {
+                    Expr::Object(obj) => Some(obj),
+                    Expr::Ident(ident) => object_by_name.get(ident.sym.as_ref()).copied(),
+                    _ => None,
+                };
+                if let Some(obj) = root {
                     Self::extract_config_from_object(obj, &mut config);
                 }
             }
         }
 
         Ok(config)
+    }
+
+    /// Maps `const name = { ... }` at module top level to the object literal (for resolving
+    /// `export default name` in SvelteKit configs).
+    fn collect_top_level_object_consts(body: &[ModuleItem]) -> HashMap<&str, &ObjectLit> {
+        let mut out = HashMap::new();
+        for item in body {
+            let ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) = item else {
+                continue;
+            };
+            if var.kind != VarDeclKind::Const {
+                continue;
+            }
+            for decl in &var.decls {
+                let Pat::Ident(binding) = &decl.name else {
+                    continue;
+                };
+                let Some(Expr::Object(obj)) = decl.init.as_ref().map(|e| e.as_ref()) else {
+                    continue;
+                };
+                out.insert(binding.id.sym.as_str(), obj);
+            }
+        }
+        out
     }
 
     /// Gets a string value from a PropName.
@@ -260,6 +294,27 @@ impl SvelteConfig {
                     if key_name == "runes" {
                         if let Expr::Lit(Lit::Bool(b)) = value.as_ref() {
                             config.compiler_options.runes = Some(b.value);
+                        }
+                    } else if key_name == "experimental" {
+                        if let Expr::Object(exp_obj) = value.as_ref() {
+                            Self::extract_compiler_experimental(exp_obj, config);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn extract_compiler_experimental(obj: &ObjectLit, config: &mut SvelteConfig) {
+        for prop in &obj.props {
+            if let PropOrSpread::Prop(prop) = prop {
+                if let Prop::KeyValue(KeyValueProp { key, value }) = prop.as_ref() {
+                    let Some(key_name) = Self::prop_name_str(key) else {
+                        continue;
+                    };
+                    if key_name == "async" {
+                        if let Expr::Lit(Lit::Bool(b)) = value.as_ref() {
+                            config.compiler_options.experimental_async = Some(b.value);
                         }
                     }
                 }
@@ -551,6 +606,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_sveltekit_bundler_config_includes_experimental_async() {
+        let path = Utf8Path::new("../../test-fixtures/projects/sveltekit-bundler");
+        let config = SvelteConfig::load(path);
+        assert_eq!(
+            config.compiler_options.experimental_async,
+            Some(true),
+            "expected const config + export default to resolve compilerOptions.experimental.async"
+        );
+    }
+
+    #[test]
     fn test_parse_svelte_config_js() {
         // Parse the test fixture svelte.config.js
         let path = Utf8Path::new("../../test-fixtures/projects/simple-app");
@@ -582,7 +648,10 @@ mod tests {
                     }
                 },
                 compilerOptions: {
-                    runes: true
+                    runes: true,
+                    experimental: {
+                        async: true
+                    }
                 }
             };
         "#;
@@ -601,6 +670,7 @@ mod tests {
             Some(&"./src/utils".to_string())
         );
         assert_eq!(config.compiler_options.runes, Some(true));
+        assert_eq!(config.compiler_options.experimental_async, Some(true));
 
         // Cleanup
         std::fs::remove_file(config_path).ok();

--- a/crates/svelte-check-rs/src/orchestrator.rs
+++ b/crates/svelte-check-rs/src/orchestrator.rs
@@ -3,7 +3,10 @@
 use crate::cli::{Args, TimingFormat};
 use crate::config::{SvelteConfig, SvelteFileKind, TsConfig};
 use crate::output::{CheckSummary, FormattedDiagnostic, Formatter, Position};
-use bun_runner::{BunCompileOptions, BunDiagnostic, BunDiagnosticSeverity, BunInput, BunRunner};
+use bun_runner::{
+    BunCompileOptions, BunDiagnostic, BunDiagnosticSeverity, BunExperimentalOptions, BunInput,
+    BunRunner,
+};
 use camino::{Utf8Path, Utf8PathBuf};
 use globset::{Glob, GlobSetBuilder};
 use rayon::prelude::*;
@@ -196,7 +199,17 @@ pub async fn run(args: Args) -> Result<CheckSummary, OrchestratorError> {
     // Load configuration
     let svelte_config = SvelteConfig::load(&workspace);
     let extra_paths = svelte_alias_paths(&svelte_config);
-    let compiler_runes = svelte_config.compiler_options.runes;
+    let compiler_bun_options = BunCompileOptions {
+        runes: svelte_config.compiler_options.runes,
+        dev: None,
+        generate: None,
+        experimental: svelte_config
+            .compiler_options
+            .experimental_async
+            .map(|enabled| BunExperimentalOptions {
+                async_: Some(enabled),
+            }),
+    };
 
     // Load tsconfig to detect module resolution strategy
     let ts_config_path = if let Some(ref custom_path) = args.tsconfig {
@@ -372,7 +385,7 @@ pub async fn run(args: Args) -> Result<CheckSummary, OrchestratorError> {
             files,
             file_scan_time,
             use_nodenext_imports,
-            compiler_runes,
+            compiler_bun_options,
             &extra_paths,
         )
         .await
@@ -383,7 +396,7 @@ pub async fn run(args: Args) -> Result<CheckSummary, OrchestratorError> {
             files,
             file_scan_time,
             use_nodenext_imports,
-            compiler_runes,
+            compiler_bun_options,
             &extra_paths,
         )
         .await
@@ -397,7 +410,7 @@ async fn run_single_check(
     files: Vec<Utf8PathBuf>,
     file_scan_time: Option<std::time::Duration>,
     use_nodenext_imports: bool,
-    compiler_runes: Option<bool>,
+    compiler_bun_options: BunCompileOptions,
     extra_paths: &HashMap<String, Vec<String>>,
 ) -> Result<CheckSummary, OrchestratorError> {
     let total_start = Instant::now();
@@ -585,11 +598,7 @@ async fn run_single_check(
             let compiler_input = Some(BunInput {
                 filename: file_path.clone(),
                 source: source.clone(),
-                options: BunCompileOptions {
-                    runes: compiler_runes,
-                    dev: None,
-                    generate: None,
-                },
+                options: compiler_bun_options.clone(),
             });
 
             FileResult {
@@ -1487,7 +1496,7 @@ async fn run_watch_mode(
     initial_files: Vec<Utf8PathBuf>,
     file_scan_time: Option<std::time::Duration>,
     use_nodenext_imports: bool,
-    compiler_runes: Option<bool>,
+    compiler_bun_options: BunCompileOptions,
     extra_paths: &HashMap<String, Vec<String>>,
 ) -> Result<CheckSummary, OrchestratorError> {
     use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
@@ -1502,7 +1511,7 @@ async fn run_watch_mode(
         initial_files.clone(),
         file_scan_time,
         use_nodenext_imports,
-        compiler_runes,
+        compiler_bun_options.clone(),
         extra_paths,
     )
     .await?;
@@ -1550,7 +1559,7 @@ async fn run_watch_mode(
                 initial_files.clone(),
                 file_scan_time,
                 use_nodenext_imports,
-                compiler_runes,
+                compiler_bun_options.clone(),
                 extra_paths,
             )
             .await;

--- a/crates/svelte-check-rs/tests/integration_issues.rs
+++ b/crates/svelte-check-rs/tests/integration_issues.rs
@@ -1696,3 +1696,21 @@ fn test_issue_96_state_referenced_locally_not_duplicated() {
         count, diagnostics
     );
 }
+
+// ============================================================================
+// ISSUE #121: experimental.async from svelte.config.js for Svelte compiler
+// ============================================================================
+//
+// `svelte-check-rs` must pass `compilerOptions.experimental.async` through to
+// `svelte/compiler` so top-level / template `await` matches project config.
+//
+// Fixture: src/routes/issue-121-experimental-async/+page.svelte
+// Config: test-fixtures/projects/sveltekit-bundler/svelte.config.js
+#[test]
+fn test_issue_121_experimental_async_respected_by_compiler() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let (_exit_code, diagnostics) = run_check_json(&fixture_path);
+    let diagnostics = filter_diagnostics_by_source(&diagnostics, "svelte");
+
+    assert_no_diagnostics_in_file(&diagnostics, "issue-121-experimental-async/+page.svelte");
+}

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-121-experimental-async/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-121-experimental-async/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	const value = await Promise.resolve(42);
+</script>
+
+<p>{value}</p>

--- a/test-fixtures/projects/sveltekit-bundler/svelte.config.js
+++ b/test-fixtures/projects/sveltekit-bundler/svelte.config.js
@@ -12,6 +12,12 @@ const config = {
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
 		adapter: adapter()
+	},
+
+	compilerOptions: {
+		experimental: {
+			async: true
+		}
 	}
 };
 


### PR DESCRIPTION
## Summary

Closes #121. Parse `compilerOptions.experimental.async` from `svelte.config.js`, resolve `export default config` when `config` is a top-level `const` object (SvelteKit default style), and pass `experimental` through the bun runner into `svelte/compiler`.

## Testing

- `test_issue_121_experimental_async_respected_by_compiler` (integration)
- Config unit tests for `experimental.async` and bundler fixture parsing
