### PR TITLE
Claude/parser parity fixes

### DIFF
--- a/crates/svelte-parser/src/lib.rs
+++ b/crates/svelte-parser/src/lib.rs
@@ -42,6 +42,11 @@ pub use source_map::Span;
 pub struct ParseOptions {
     /// Whether to enable tracing for debugging.
     pub trace: bool,
+    /// Loose mode: best-effort recovery without surfacing parse errors.
+    /// Mirrors the behavior of upstream Svelte's loose parser, used for
+    /// editor / language-server scenarios where the source is expected to
+    /// be in-progress and incomplete.
+    pub loose: bool,
 }
 
 /// The result of parsing a Svelte file.

--- a/crates/svelte-parser/src/parser.rs
+++ b/crates/svelte-parser/src/parser.rs
@@ -60,7 +60,6 @@ pub struct Parser<'src> {
     /// Parse errors collected during parsing.
     errors: Vec<ParseError>,
     /// Parser options.
-    #[allow(dead_code)]
     options: ParseOptions,
     /// EOF token for when we're past the end
     eof_token: Token,
@@ -149,7 +148,16 @@ impl<'src> Parser<'src> {
 
     /// Reports an error at the current position.
     fn error(&mut self, kind: ParseErrorKind) {
-        self.errors.push(ParseError::new(kind, self.current().span));
+        let span = self.current().span;
+        self.error_at(kind, span);
+    }
+
+    /// Reports an error at a specific span. Suppressed in loose mode.
+    fn error_at(&mut self, kind: ParseErrorKind, span: Span) {
+        if self.options.loose {
+            return;
+        }
+        self.errors.push(ParseError::new(kind, span));
     }
 
     /// Skips whitespace and newlines.
@@ -1669,12 +1677,13 @@ impl<'src> Parser<'src> {
 
             // Error if directive name is empty (e.g., style:, on:, bind:)
             if remaining.is_empty() {
-                self.errors.push(ParseError::new(
+                let span = Span::new(start, self.current().span.end);
+                self.error_at(
                     ParseErrorKind::InvalidDirective {
                         message: format!("`{}:` name cannot be empty", directive_name),
                     },
-                    Span::new(start, self.current().span.end),
-                ));
+                    span,
+                );
             }
 
             // Parse value - directives can have expression or quoted string values
@@ -2828,10 +2837,10 @@ impl<'src> Parser<'src> {
             )
         };
 
-        self.errors.push(ParseError::new(
+        self.error_at(
             ParseErrorKind::InvalidBlockSyntax { message },
             Span::new(start, end),
-        ));
+        );
 
         None
     }

--- a/crates/svelte-parser/src/parser.rs
+++ b/crates/svelte-parser/src/parser.rs
@@ -42,6 +42,13 @@ fn has_optional_end_tag(name: &str) -> bool {
     matches!(name, "li")
 }
 
+/// Returns true if the element's children are parsed as raw text (with
+/// mustache expressions still recognized). HTML "escapable raw text"
+/// elements: `<textarea>` and `<title>`.
+fn is_escapable_raw_text(name: &str) -> bool {
+    matches!(name.to_ascii_lowercase().as_str(), "textarea" | "title")
+}
+
 /// The Svelte parser.
 pub struct Parser<'src> {
     /// The source being parsed.
@@ -1330,6 +1337,8 @@ impl<'src> Parser<'src> {
         // Parse children if not self-closing
         let children = if self_closing {
             Vec::new()
+        } else if is_escapable_raw_text(&name) {
+            self.parse_raw_text_children(&name)
         } else {
             self.parse_children(&name)
         };
@@ -2043,6 +2052,94 @@ impl<'src> Parser<'src> {
     }
 
     /// Parses children until a closing tag.
+    /// Parses children of an HTML escapable raw-text element (`<textarea>`,
+    /// `<title>`). Content is treated as raw text — nested HTML markup is
+    /// not interpreted — except that `{...}` mustache expressions remain
+    /// active. The element terminates at `</tagname` followed by whitespace,
+    /// `/`, `>`, or EOF (case-insensitive).
+    fn parse_raw_text_children(&mut self, parent_tag: &str) -> Vec<TemplateNode> {
+        let mut children = Vec::new();
+        let parent_lc = parent_tag.to_ascii_lowercase();
+        let bytes = self.source.as_bytes();
+
+        while !self.check(TokenKind::Eof) {
+            let cur_offset = u32::from(self.current().span.start) as usize;
+
+            if self.is_real_close_tag_at(cur_offset, &parent_lc) {
+                break;
+            }
+
+            if bytes.get(cur_offset) == Some(&b'{')
+                && !matches!(
+                    bytes.get(cur_offset + 1),
+                    Some(b'@') | Some(b'#') | Some(b':')
+                )
+            {
+                if let Some(node) = self.parse_expression_tag() {
+                    children.push(node);
+                    continue;
+                }
+            }
+
+            // Read raw text up to the next `{` or real closing tag.
+            let text_start_offset = cur_offset;
+            let mut end_offset = cur_offset;
+            while end_offset < bytes.len() {
+                if bytes[end_offset] == b'{' {
+                    break;
+                }
+                if bytes[end_offset] == b'<'
+                    && end_offset + 1 < bytes.len()
+                    && bytes[end_offset + 1] == b'/'
+                    && self.is_real_close_tag_at(end_offset, &parent_lc)
+                {
+                    break;
+                }
+                end_offset += 1;
+            }
+            if end_offset == text_start_offset {
+                // No progress: avoid infinite loop.
+                self.advance();
+                continue;
+            }
+            let text = self.source[text_start_offset..end_offset].to_string();
+            let is_whitespace = text.chars().all(|c| c.is_whitespace());
+            let span = Span::new(self.current().span.start, TextSize::from(end_offset as u32));
+            while !self.check(TokenKind::Eof) && self.current().span.end <= span.end {
+                self.advance();
+            }
+            children.push(TemplateNode::Text(Text {
+                span,
+                data: text,
+                is_whitespace,
+            }));
+        }
+
+        children
+    }
+
+    /// Returns true if the source at `offset` is a "real" `</tagname` closing
+    /// tag for `expected_lc` — i.e. `</tagname` followed by whitespace, `/`,
+    /// `>`, or EOF.
+    fn is_real_close_tag_at(&self, offset: usize, expected_lc: &str) -> bool {
+        let bytes = self.source.as_bytes();
+        if offset + 2 + expected_lc.len() > bytes.len() {
+            return false;
+        }
+        if bytes[offset] != b'<' || bytes[offset + 1] != b'/' {
+            return false;
+        }
+        let name_start = offset + 2;
+        let name_end = name_start + expected_lc.len();
+        if !self.source[name_start..name_end].eq_ignore_ascii_case(expected_lc) {
+            return false;
+        }
+        match bytes.get(name_end) {
+            None => true,
+            Some(&b) => b.is_ascii_whitespace() || matches!(b, b'/' | b'>'),
+        }
+    }
+
     fn parse_children(&mut self, parent_tag: &str) -> Vec<TemplateNode> {
         let mut children = Vec::new();
         let close_tag = format!("</{}", parent_tag);
@@ -2161,6 +2258,8 @@ impl<'src> Parser<'src> {
             });
         }
 
+        // Tolerate whitespace between the tag name and `>` (e.g. `</textarea\n>`).
+        self.skip_whitespace();
         self.eat(TokenKind::RAngle);
     }
 

--- a/crates/svelte-parser/src/parser.rs
+++ b/crates/svelte-parser/src/parser.rs
@@ -1391,6 +1391,7 @@ impl<'src> Parser<'src> {
 
         loop {
             self.skip_whitespace();
+            self.skip_tag_comments();
 
             if self.check(TokenKind::RAngle)
                 || self.check(TokenKind::SlashRAngle)
@@ -1407,6 +1408,46 @@ impl<'src> Parser<'src> {
         }
 
         attributes
+    }
+
+    /// Skips `// line` and `/* block */` comments that may appear between
+    /// attributes inside an element opening tag.
+    fn skip_tag_comments(&mut self) {
+        loop {
+            let offset = u32::from(self.current().span.start) as usize;
+            let bytes = self.source.as_bytes();
+            if offset + 1 >= bytes.len() || bytes[offset] != b'/' {
+                return;
+            }
+            let end_offset = match bytes[offset + 1] {
+                b'/' => {
+                    // Line comment: consume to next newline (exclusive).
+                    let mut e = offset + 2;
+                    while e < bytes.len() && bytes[e] != b'\n' {
+                        e += 1;
+                    }
+                    e
+                }
+                b'*' => {
+                    // Block comment: consume to closing `*/`.
+                    let mut e = offset + 2;
+                    while e + 1 < bytes.len() && !(bytes[e] == b'*' && bytes[e + 1] == b'/') {
+                        e += 1;
+                    }
+                    if e + 1 < bytes.len() {
+                        e + 2
+                    } else {
+                        bytes.len()
+                    }
+                }
+                _ => return,
+            };
+            let end = TextSize::from(end_offset as u32);
+            while !self.check(TokenKind::Eof) && self.current().span.end <= end {
+                self.advance();
+            }
+            self.skip_whitespace();
+        }
     }
 
     /// Parses a single attribute.

--- a/crates/svelte-parser/src/parser.rs
+++ b/crates/svelte-parser/src/parser.rs
@@ -1741,8 +1741,40 @@ impl<'src> Parser<'src> {
                 is_quoted: false,
             })
         } else {
-            AttributeValue::True
+            self.parse_unquoted_attribute_value()
         }
+    }
+
+    /// Parses an unquoted attribute value, e.g. `class=foo`, `href=https://x.y/z`.
+    ///
+    /// Per the HTML spec, unquoted values are terminated by whitespace, `>`,
+    /// `=`, `<`, `"`, `'`, or `` ` ``. `/` is permitted inside the value, so
+    /// `<a href=/>` has value "/" (the element is not self-closing).
+    fn parse_unquoted_attribute_value(&mut self) -> AttributeValue {
+        let start = self.current().span.start;
+        let start_offset = u32::from(start) as usize;
+        let bytes = self.source.as_bytes();
+        let mut end_offset = start_offset;
+        while end_offset < bytes.len() {
+            let b = bytes[end_offset];
+            if b.is_ascii_whitespace() || matches!(b, b'>' | b'<' | b'=' | b'"' | b'\'' | b'`') {
+                break;
+            }
+            end_offset += 1;
+        }
+        if end_offset == start_offset {
+            return AttributeValue::True;
+        }
+        let end = TextSize::from(end_offset as u32);
+        let span = Span::new(start, end);
+        let value = self.source[start_offset..end_offset].to_string();
+
+        // Advance past tokens covered by the unquoted value.
+        while !self.check(TokenKind::Eof) && self.current().span.end <= end {
+            self.advance();
+        }
+
+        AttributeValue::Text(TextValue { span, value })
     }
 
     /// Parses a quoted attribute value that may contain expressions.

--- a/crates/svelte-parser/src/parser.rs
+++ b/crates/svelte-parser/src/parser.rs
@@ -20,6 +20,28 @@ fn is_void_element(name: &str) -> bool {
     HTML_VOID_ELEMENTS.contains(&name.to_lowercase().as_str())
 }
 
+/// Returns true if `parent` should be implicitly closed when an opening tag
+/// `<child>` is encountered. Mirrors HTML5 optional-end-tag rules.
+fn implicit_close_on_open(parent: &str, child: &str) -> bool {
+    matches!((parent, child), ("li", "li"))
+}
+
+/// Returns true if `parent` should be implicitly closed when a closing tag
+/// `</closing>` is encountered.
+fn implicit_close_on_close(parent: &str, closing: &str) -> bool {
+    matches!(
+        (parent, closing),
+        ("li", "ul") | ("li", "ol") | ("li", "menu")
+    )
+}
+
+/// Returns true if the element's end tag may be omitted per the HTML spec.
+/// Currently only covers `<li>` (the tags exercised by the upstream parity
+/// suite); extend as additional cases surface.
+fn has_optional_end_tag(name: &str) -> bool {
+    matches!(name, "li")
+}
+
 /// The Svelte parser.
 pub struct Parser<'src> {
     /// The source being parsed.
@@ -1960,6 +1982,7 @@ impl<'src> Parser<'src> {
     fn parse_children(&mut self, parent_tag: &str) -> Vec<TemplateNode> {
         let mut children = Vec::new();
         let close_tag = format!("</{}", parent_tag);
+        let parent_lc = parent_tag.to_ascii_lowercase();
 
         while !self.check(TokenKind::Eof) {
             // Check for closing tag
@@ -1973,9 +1996,20 @@ impl<'src> Parser<'src> {
                 break;
             }
 
+            // Implicit close: a new opening tag that closes the parent (e.g. <li> in <li>).
+            if let Some(next_tag) = self.peek_opening_tag_name() {
+                if implicit_close_on_open(&parent_lc, &next_tag) {
+                    break;
+                }
+            }
+
             if let Some(node) = self.parse_template_node() {
                 children.push(node);
-            } else if !self.check(TokenKind::Eof) && !self.check(TokenKind::LAngleSlash) {
+            } else if !self.check(TokenKind::Eof)
+                && !self.check(TokenKind::LAngleSlash)
+                && !self.check(TokenKind::LBraceSlash)
+                && !self.check(TokenKind::LBraceColon)
+            {
                 self.advance();
             } else {
                 break;
@@ -1987,10 +2021,34 @@ impl<'src> Parser<'src> {
 
     /// Parses a closing tag.
     fn parse_closing_tag(&mut self, expected_name: &str) {
+        let expected_lc = expected_name.to_ascii_lowercase();
+
+        // Implicit close (sibling opening): the upcoming opening tag closes
+        // the parent (e.g. <li> while still inside <li>). Don't emit an error
+        // and don't consume anything; the sibling will be handled by the
+        // grandparent.
+        if let Some(opening) = self.peek_opening_tag_name() {
+            if implicit_close_on_open(&expected_lc, &opening) {
+                return;
+            }
+        }
+
+        // Implicit close (ancestor closing): the upcoming closing tag is for
+        // an ancestor (e.g. </ul> while inside <li>). Don't consume it.
+        if let Some(closing) = self.peek_closing_tag_name() {
+            if closing != expected_lc && implicit_close_on_close(&expected_lc, &closing) {
+                return;
+            }
+        }
+
         if !self.eat(TokenKind::LAngleSlash) {
-            self.error(ParseErrorKind::UnclosedTag {
-                tag_name: expected_name.to_string(),
-            });
+            // Elements with optional end tags (per HTML spec) silently close
+            // when no `</tag>` is present.
+            if !has_optional_end_tag(&expected_lc) {
+                self.error(ParseErrorKind::UnclosedTag {
+                    tag_name: expected_name.to_string(),
+                });
+            }
             return;
         }
 
@@ -2524,6 +2582,50 @@ impl<'src> Parser<'src> {
     fn check_source(&self, s: &str) -> bool {
         let offset = u32::from(self.current().span.start) as usize;
         self.source[offset..].starts_with(s)
+    }
+
+    /// If the current position starts an opening tag (`<name`), returns the
+    /// lowercased tag name. Does not advance.
+    fn peek_opening_tag_name(&self) -> Option<String> {
+        if !self.check(TokenKind::LAngle) {
+            return None;
+        }
+        let lt_end = u32::from(self.current().span.end) as usize;
+        let bytes = self.source.as_bytes();
+        if lt_end >= bytes.len() {
+            return None;
+        }
+        let first = bytes[lt_end];
+        if !first.is_ascii_alphabetic() {
+            return None;
+        }
+        let mut end = lt_end;
+        while end < bytes.len()
+            && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'-' | b'_' | b':'))
+        {
+            end += 1;
+        }
+        Some(self.source[lt_end..end].to_ascii_lowercase())
+    }
+
+    /// If the current position starts a closing tag (`</name`), returns the
+    /// lowercased tag name. Does not advance.
+    fn peek_closing_tag_name(&self) -> Option<String> {
+        if !self.check(TokenKind::LAngleSlash) {
+            return None;
+        }
+        let slash_end = u32::from(self.current().span.end) as usize;
+        let bytes = self.source.as_bytes();
+        let mut end = slash_end;
+        while end < bytes.len()
+            && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'-' | b'_' | b':'))
+        {
+            end += 1;
+        }
+        if end == slash_end {
+            return None;
+        }
+        Some(self.source[slash_end..end].to_ascii_lowercase())
     }
 
     /// Handles an invalid block continuation tag like {:els} (typo for {:else}).

--- a/crates/svelte-parser/src/parser.rs
+++ b/crates/svelte-parser/src/parser.rs
@@ -1685,6 +1685,29 @@ impl<'src> Parser<'src> {
                         expression: expr,
                         is_quoted: false,
                     })
+                } else if self.check(TokenKind::LBraceSlash) {
+                    // Lexer collapsed `{//` (line comment) or `{/*` (block
+                    // comment) into LBraceSlash. Read the whole `{...}` from
+                    // source.
+                    let lbrace_start = self.current().span.start;
+                    let start_offset = u32::from(lbrace_start) as usize;
+                    let (expr, expr_span) = self.read_expression_from_offset(start_offset + 1, '}');
+                    let expr_end = expr_span.end;
+                    while !self.check(TokenKind::Eof) && self.current().span.end <= expr_end {
+                        self.advance();
+                    }
+                    self.eat(TokenKind::RBrace);
+                    let end = self
+                        .tokens
+                        .get(self.pos.saturating_sub(1))
+                        .map(|t| t.span.end)
+                        .unwrap_or(lbrace_start);
+                    Some(ExpressionValue {
+                        span: Span::new(lbrace_start, end),
+                        expression_span: expr_span,
+                        expression: expr,
+                        is_quoted: false,
+                    })
                 } else if self.check(TokenKind::DoubleQuote) || self.check(TokenKind::SingleQuote) {
                     // Handle quoted string values like style:color="red"
                     let quote = if self.check(TokenKind::DoubleQuote) {


### PR DESCRIPTION
## Summary

Using the #111 billpeet/svelte-check-rs parser-upstream-corpus-33 branch I had Claude iterate to bring `svelte-parser` to parity with the upstream parser corpus.

Also added a new `ParseOptions.loose` mode mirroring upstream's tolerant-recovery parser, but following upstream's example, `loose` is not exposed as a cli option.

## Details

| Commit | Fix |
|---|---|
| `fix(parser): support unquoted attribute values` | `<a href=https://x.y/z>` and `<a href=/>home</a>` now parse — values are read raw from source until an HTML attribute terminator, with `/` permitted inside the value per the HTML spec. |
| `fix(parser): support implicit closing of <li>` | HTML5 optional-end-tag rules: `<li>` self-closes on a sibling `<li>` opening or a `</ul>` / `</ol>` / `</menu>` ancestor close. `parse_children` also breaks at block-closing `{/...}` and continuation `{:...}` tokens so a nested element doesn't swallow its enclosing block's terminator. |
| `fix(parser): skip JS-style comments between attributes` | `// line` and `/* block */` comments inside an opening tag (between attributes) are skipped. |
| `fix(parser): handle '{//' and '{/*' comments in directive values` | The lexer collapses `{/` into `LBraceSlash`; the directive expression branch now recognizes it, matching the existing handling for normal attribute values. |
| `fix(parser): handle <textarea> as escapable raw-text element` | Per the HTML spec, `<textarea>` (and `<title>`) contents are raw text — nested HTML markup is not parsed — but mustache `{...}` remains active. Adds `parse_raw_text_children`. Also tolerates whitespace between the end-tag name and `>`. |
| `feat(parser): add loose mode for tolerant recovery` | Adds `loose: bool` to `ParseOptions`. Funnels all error reporting through `error_at(kind, span)` which no-ops when `loose` is set. Behaviorally matches upstream's loose parser: produces an AST, suppresses recovery diagnostics. |

## Rationale

Before these fixes, 7 of the 97 strict samples in the upstream Svelte parser test corpus (`parser-modern` + `parser-legacy`, 107 samples total) failed against `svelte-parser`. After, all 97 pass, and the 10 `loose-*` samples additionally pass when parsed with `ParseOptions { loose: true, .. }`.

Verified using the harness from #111 with a local checkout of `sveltejs/svelte`, but this PR is independent of #111; it touches only library source and adds no test wiring. The existing `cargo test -p svelte-parser` suite (141 unit tests + 56 snapshot tests) continues to pass without modification.

## Testing

```bash
cargo test --workspace
cargo clippy --all-targets -- -D warnings
cargo fmt --check