### PR TITLE
fix(cli): warn and skip files with unregistered extensions (#126)

### DIFF
--- a/crates/svelte-check-rs/src/config.rs
+++ b/crates/svelte-check-rs/src/config.rs
@@ -12,6 +12,12 @@ use swc_ecma_ast::{
 };
 use swc_ecma_parser::{parse_file_as_module, EsSyntax, Syntax, TsSyntax};
 
+/// Extensions svelte-check-rs natively understands.
+///
+/// Longer suffixes first so a filename like `foo.svelte.ts` matches
+/// `.svelte.ts` rather than `.svelte`.
+const NATIVE_EXTENSIONS: &[&str] = &[".svelte.ts", ".svelte.js", ".svelte"];
+
 /// The kind of Svelte file being processed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SvelteFileKind {
@@ -322,20 +328,40 @@ impl SvelteConfig {
         }
     }
 
-    /// Returns the default file extensions to process.
+    /// Returns the file extensions to walk during discovery.
     ///
-    /// By default, processes:
+    /// Always includes the natively-supported extensions:
     /// - `.svelte` - Component files
     /// - `.svelte.ts` - TypeScript module files with runes
     /// - `.svelte.js` - JavaScript module files with runes
+    ///
+    /// Any extra extensions declared in `svelte.config.js` (e.g. `.svx` from
+    /// mdsvex) are appended so they are still discovered and reported, but the
+    /// orchestrator filters out the unrecognized ones with a user-facing
+    /// warning rather than feeding them into the type-checker.
+    ///
+    /// Order matters: longer suffixes must come before `.svelte` so that
+    /// `.svelte.ts` matches before `.svelte`.
     pub fn file_extensions(&self) -> Vec<&str> {
-        if self.extensions.is_empty() {
-            // Note: Order matters! .svelte.ts/.svelte.js must come before .svelte
-            // to ensure proper matching (longer suffixes first)
-            vec![".svelte.ts", ".svelte.js", ".svelte"]
-        } else {
-            self.extensions.iter().map(|s| s.as_str()).collect()
+        let mut extensions: Vec<&str> = NATIVE_EXTENSIONS.to_vec();
+        for ext in &self.extensions {
+            let s = ext.as_str();
+            if !extensions.contains(&s) {
+                extensions.push(s);
+            }
         }
+        extensions
+    }
+
+    /// Returns extensions declared in `svelte.config.js` that we don't
+    /// natively support. Files with these extensions are discovered (so we can
+    /// report them) but skipped from the rest of the pipeline.
+    pub fn unsupported_extensions(&self) -> Vec<&str> {
+        self.extensions
+            .iter()
+            .map(|s| s.as_str())
+            .filter(|s| !NATIVE_EXTENSIONS.contains(s))
+            .collect()
     }
 
     /// Returns whether runes mode is enabled (defaults to true for Svelte 5).
@@ -718,5 +744,49 @@ mod tests {
         // Default does not require explicit extensions
         let opts = CompilerOptions::default();
         assert!(!opts.requires_explicit_extensions());
+    }
+
+    #[test]
+    fn test_file_extensions_defaults_when_unset() {
+        let config = SvelteConfig::default();
+        assert_eq!(
+            config.file_extensions(),
+            vec![".svelte.ts", ".svelte.js", ".svelte"]
+        );
+        assert!(config.unsupported_extensions().is_empty());
+    }
+
+    #[test]
+    fn test_file_extensions_merges_with_user_extensions() {
+        // Issue #126: when svelte.config.js declares extensions like `.svx`
+        // from mdsvex, we still need to discover the natively-supported ones
+        // (`.svelte`, `.svelte.ts`, `.svelte.js`) AND the user's extras.
+        let config = SvelteConfig {
+            extensions: vec![".svelte".to_string(), ".svx".to_string()],
+            ..Default::default()
+        };
+        let extensions = config.file_extensions();
+        assert!(extensions.contains(&".svelte"));
+        assert!(extensions.contains(&".svelte.ts"));
+        assert!(extensions.contains(&".svelte.js"));
+        assert!(extensions.contains(&".svx"));
+        // `.svelte` listed twice (once natively, once by user) must dedupe.
+        assert_eq!(extensions.iter().filter(|e| **e == ".svelte").count(), 1);
+    }
+
+    #[test]
+    fn test_unsupported_extensions_excludes_natives() {
+        let config = SvelteConfig {
+            extensions: vec![
+                ".svelte".to_string(),
+                ".svelte.ts".to_string(),
+                ".svx".to_string(),
+                ".mdx".to_string(),
+            ],
+            ..Default::default()
+        };
+        let mut unsupported = config.unsupported_extensions();
+        unsupported.sort();
+        assert_eq!(unsupported, vec![".mdx", ".svx"]);
     }
 }

--- a/crates/svelte-check-rs/src/orchestrator.rs
+++ b/crates/svelte-check-rs/src/orchestrator.rs
@@ -11,7 +11,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use globset::{Glob, GlobSetBuilder};
 use rayon::prelude::*;
 use source_map::LineIndex;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
@@ -25,6 +25,54 @@ use tsgo_runner::{
 use walkdir::WalkDir;
 
 const SHARED_HELPERS_MODULE: &str = "__svelte_check_rs_helpers";
+
+/// Returns the extension label (with leading dot) we should display for a
+/// discovered file whose `SvelteFileKind` is unrecognized. Prefers the longest
+/// configured user extension that the filename ends with; falls back to the
+/// raw `Path::extension()` so unexpected files still get a useful label.
+fn unsupported_extension_label(file_name: &str, user_extensions: &[&str]) -> String {
+    let mut best: Option<&str> = None;
+    for ext in user_extensions {
+        if !file_name.ends_with(ext) {
+            continue;
+        }
+        match best {
+            None => best = Some(ext),
+            Some(prev) if ext.len() > prev.len() => best = Some(ext),
+            _ => {}
+        }
+    }
+    if let Some(ext) = best {
+        return ext.to_string();
+    }
+    match file_name.rsplit_once('.') {
+        Some((_, ext)) if !ext.is_empty() => format!(".{}", ext),
+        _ => file_name.to_string(),
+    }
+}
+
+/// Builds the per-extension "N files with unregistered extension (.X) skipped"
+/// warning lines for files we discovered but can't process.
+fn format_unsupported_warnings(files: &[Utf8PathBuf], user_extensions: &[&str]) -> Vec<String> {
+    if files.is_empty() {
+        return Vec::new();
+    }
+    let mut by_ext: BTreeMap<String, usize> = BTreeMap::new();
+    for f in files {
+        let label = unsupported_extension_label(f.file_name().unwrap_or(""), user_extensions);
+        *by_ext.entry(label).or_insert(0) += 1;
+    }
+    by_ext
+        .into_iter()
+        .map(|(ext, count)| {
+            let plural = if count == 1 { "file" } else { "files" };
+            format!(
+                "warning: {} {} with unregistered extension ({}) skipped",
+                count, plural, ext
+            )
+        })
+        .collect()
+}
 
 fn ensure_relative_path(path: &Utf8Path) -> Utf8PathBuf {
     if !path.is_absolute() {
@@ -343,6 +391,22 @@ pub async fn run(args: Args) -> Result<CheckSummary, OrchestratorError> {
     } else {
         None
     };
+
+    // Split off files whose extension we don't natively understand (e.g. `.svx`
+    // from mdsvex). They were registered in `svelte.config.js#extensions` so
+    // they showed up in the walk, but we can't transform them — feeding them to
+    // the Svelte/TS pipeline would either be silently dropped or break tsgo. We
+    // warn the user once per extension and exclude them from everything below.
+    let (files, unsupported_files): (Vec<_>, Vec<_>) = files
+        .into_iter()
+        .partition(|f| SvelteFileKind::from_path(f).is_some());
+
+    if !unsupported_files.is_empty() {
+        let user_extensions = svelte_config.unsupported_extensions();
+        for line in format_unsupported_warnings(&unsupported_files, &user_extensions) {
+            eprintln!("{}", line);
+        }
+    }
 
     // Handle --single-file flag: filter to just the specified file
     let files = if let Some(ref single_file) = args.single_file {
@@ -1648,6 +1712,45 @@ mod tests {
 
         // Patterns with * but no ** should be unchanged
         assert_eq!(normalize_tsconfig_pattern("src/*.test.ts"), "src/*.test.ts");
+    }
+
+    #[test]
+    fn test_unsupported_extension_label_prefers_longest_user_extension() {
+        let label = unsupported_extension_label("page.svx", &[".svx"]);
+        assert_eq!(label, ".svx");
+
+        // Longer configured extension should win over a shorter one.
+        let label = unsupported_extension_label("page.svelte.md", &[".md", ".svelte.md"]);
+        assert_eq!(label, ".svelte.md");
+    }
+
+    #[test]
+    fn test_unsupported_extension_label_falls_back_to_path_extension() {
+        // No user extension matches → fall back to the trailing dotted suffix.
+        let label = unsupported_extension_label("notes.txt", &[]);
+        assert_eq!(label, ".txt");
+    }
+
+    #[test]
+    fn test_format_unsupported_warnings_groups_by_extension() {
+        let files = vec![
+            Utf8PathBuf::from("src/a.svx"),
+            Utf8PathBuf::from("src/b.svx"),
+            Utf8PathBuf::from("src/c.mdx"),
+        ];
+        let lines = format_unsupported_warnings(&files, &[".svx", ".mdx"]);
+        assert_eq!(
+            lines,
+            vec![
+                "warning: 1 file with unregistered extension (.mdx) skipped".to_string(),
+                "warning: 2 files with unregistered extension (.svx) skipped".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_format_unsupported_warnings_empty() {
+        assert!(format_unsupported_warnings(&[], &[]).is_empty());
     }
 
     #[test]

--- a/crates/svelte-check-rs/src/output.rs
+++ b/crates/svelte-check-rs/src/output.rs
@@ -265,21 +265,28 @@ impl CheckSummary {
         } else {
             "warnings"
         };
-        let file_word = if self.file_count == 1 {
-            "file"
-        } else {
-            "files"
-        };
 
-        format!(
-            "====================================\nsvelte-check-rs found {} {} and {} {} in {} {}",
-            self.error_count,
-            error_word,
-            self.warning_count,
-            warning_word,
-            self.file_count,
-            file_word
-        )
+        if self.file_count == 0 {
+            format!(
+                "svelte-check-rs found {} {} and {} {}",
+                self.error_count, error_word, self.warning_count, warning_word
+            )
+        } else {
+            let file_word = if self.file_count == 1 {
+                "file"
+            } else {
+                "files"
+            };
+            format!(
+                "====================================\nsvelte-check-rs found {} {} and {} {} in {} {}",
+                self.error_count,
+                error_word,
+                self.warning_count,
+                warning_word,
+                self.file_count,
+                file_word
+            )
+        }
     }
 }
 
@@ -328,8 +335,39 @@ mod tests {
         };
 
         let output = summary.format();
+        assert!(output.contains("===="));
         assert!(output.contains("2 errors"));
         assert!(output.contains("3 warnings"));
-        assert!(output.contains("5 files"));
+        assert!(output.contains("in 5 files"));
+    }
+
+    #[test]
+    fn test_summary_clean_omits_divider_and_file_count() {
+        // Matches language-tools svelte-check: when there are no files with
+        // problems, drop both the divider line and the "in N files" suffix.
+        let summary = CheckSummary {
+            file_count: 0,
+            error_count: 0,
+            warning_count: 0,
+            fail_on_warnings: false,
+        };
+
+        let output = summary.format();
+        assert_eq!(output, "svelte-check-rs found 0 errors and 0 warnings");
+    }
+
+    #[test]
+    fn test_summary_single_file() {
+        let summary = CheckSummary {
+            file_count: 1,
+            error_count: 1,
+            warning_count: 0,
+            fail_on_warnings: false,
+        };
+
+        let output = summary.format();
+        assert!(output.contains("===="));
+        assert!(output.contains("1 error "));
+        assert!(output.contains("in 1 file"));
     }
 }

--- a/crates/svelte-check-rs/tests/integration_extensions.rs
+++ b/crates/svelte-check-rs/tests/integration_extensions.rs
@@ -1,0 +1,211 @@
+//! Integration tests for `svelte.config.js#extensions` handling (issue #126).
+//!
+//! Each test builds a self-contained project on disk under `target/test-tmp/`,
+//! runs the CLI against it with `--list-files --skip-tsgo`, and asserts on
+//! stdout/stderr. `--list-files` exits before tsgo or bun are invoked, so
+//! these tests don't require `bun install` or `tsgo` to be present.
+
+#![cfg(not(target_os = "windows"))]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn binary_path() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_svelte-check-rs") {
+        return PathBuf::from(path);
+    }
+    if let Some(path) = option_env!("CARGO_BIN_EXE_svelte-check-rs") {
+        return PathBuf::from(path);
+    }
+    workspace_root()
+        .join("target")
+        .join("debug")
+        .join("svelte-check-rs")
+}
+
+static BIN_READY: OnceLock<()> = OnceLock::new();
+
+fn ensure_binary_built() {
+    BIN_READY.get_or_init(|| {
+        let _ = Command::new("cargo")
+            .args(["build", "-p", "svelte-check-rs"])
+            .output();
+    });
+}
+
+fn make_project(name: &str) -> PathBuf {
+    let dir = workspace_root()
+        .join("target")
+        .join("test-tmp")
+        .join("integration_extensions")
+        .join(name);
+    if dir.exists() {
+        fs::remove_dir_all(&dir).expect("clear previous test dir");
+    }
+    fs::create_dir_all(dir.join("src")).expect("create project dir");
+    dir
+}
+
+fn write(path: &Path, contents: &str) {
+    fs::write(path, contents).unwrap_or_else(|e| panic!("write {}: {}", path.display(), e));
+}
+
+struct RunOutput {
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+fn run_list_files(project: &Path) -> RunOutput {
+    ensure_binary_built();
+    let output = Command::new(binary_path())
+        .arg("--workspace")
+        .arg(project)
+        .arg("--skip-tsgo")
+        .arg("--list-files")
+        .output()
+        .expect("Failed to execute svelte-check-rs");
+    RunOutput {
+        exit_code: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    }
+}
+
+fn write_minimal_tsconfig(project: &Path) {
+    write(
+        &project.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}
+"#,
+    );
+}
+
+/// Issue #126: when svelte.config.js registers a non-default extension like
+/// `.svx` (mdsvex), the checker must warn-and-skip those files instead of
+/// silently breaking the rest of the pipeline.
+#[test]
+fn test_unregistered_extension_warns_and_skips() {
+    let project = make_project("warn_and_skip_svx");
+    write(
+        &project.join("svelte.config.js"),
+        "export default { extensions: ['.svelte', '.svx'] };\n",
+    );
+    write_minimal_tsconfig(&project);
+    write(
+        &project.join("src/Hello.svelte"),
+        "<script lang=\"ts\">let name: string = 'world';</script>\n<p>Hello {name}</p>\n",
+    );
+    write(&project.join("src/post.svx"), "# A post\n");
+    write(&project.join("src/another.svx"), "# Another post\n");
+
+    let RunOutput {
+        exit_code,
+        stdout,
+        stderr,
+    } = run_list_files(&project);
+
+    assert_eq!(exit_code, 0, "exit code should be 0, stderr: {}", stderr);
+    assert!(
+        stderr.contains("warning: 2 files with unregistered extension (.svx) skipped"),
+        "expected warning about skipped .svx files, got stderr:\n{}",
+        stderr
+    );
+    assert!(
+        stdout.contains("src/Hello.svelte"),
+        "expected .svelte file to be listed, got stdout:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains(".svx"),
+        ".svx files should NOT appear in the file list, got stdout:\n{}",
+        stdout
+    );
+    assert!(
+        stderr.contains("Files to check (1)"),
+        "expected exactly 1 file to be listed, got stderr:\n{}",
+        stderr
+    );
+}
+
+/// Defaults like `.svelte.ts`/`.svelte.js` must still be discovered even when
+/// the user declares custom extensions (`extensions` should merge with the
+/// natives, not replace them).
+#[test]
+fn test_user_extensions_merge_with_native_defaults() {
+    let project = make_project("merge_defaults");
+    write(
+        &project.join("svelte.config.js"),
+        // User declares only .svelte + .svx, omitting .svelte.ts/.svelte.js.
+        // We should still pick up the .svelte.ts module file.
+        "export default { extensions: ['.svelte', '.svx'] };\n",
+    );
+    write_minimal_tsconfig(&project);
+    write(&project.join("src/App.svelte"), "<p>hi</p>\n");
+    write(
+        &project.join("src/state.svelte.ts"),
+        "export const count = $state(0);\n",
+    );
+
+    let RunOutput {
+        exit_code,
+        stdout,
+        stderr,
+    } = run_list_files(&project);
+
+    assert_eq!(exit_code, 0, "exit code should be 0, stderr: {}", stderr);
+    assert!(
+        stdout.contains("src/App.svelte"),
+        "expected .svelte file to be listed, got stdout:\n{}",
+        stdout
+    );
+    assert!(
+        stdout.contains("src/state.svelte.ts"),
+        ".svelte.ts file should still be discovered when extensions are customized, got stdout:\n{}",
+        stdout
+    );
+}
+
+/// Sanity check: a project with no custom extensions should not emit any
+/// "unregistered extension" warning.
+#[test]
+fn test_no_warning_when_only_native_extensions_present() {
+    let project = make_project("no_custom_extensions");
+    write(
+        &project.join("svelte.config.js"),
+        "export default { extensions: ['.svelte'] };\n",
+    );
+    write_minimal_tsconfig(&project);
+    write(&project.join("src/App.svelte"), "<p>hi</p>\n");
+
+    let RunOutput {
+        exit_code, stderr, ..
+    } = run_list_files(&project);
+
+    assert_eq!(exit_code, 0, "exit code should be 0, stderr: {}", stderr);
+    assert!(
+        !stderr.contains("unregistered extension"),
+        "no warning expected for native-only project, got stderr:\n{}",
+        stderr
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #126. When `svelte.config.js` declared a non-default extension like `.svx` (mdsvex), `svelte-check-rs` exited 0 with `svelte-check-rs found 0 errors and 0 warnings in 0 files` and silently checked nothing — masking real type errors in the rest of the project.

## Why

Three things were going wrong at once:

1. `SvelteConfig::file_extensions()` **replaced** the natives (`.svelte.ts`, `.svelte.js`, `.svelte`) with the user's array. With `extensions: ['.svelte', '.svx']`, that meant `.svelte.ts`/`.svelte.js` modules were also silently dropped from discovery.
2. `.svx` files matched the walker allowlist and were partitioned into the module pipeline (`SvelteFileKind::from_path` returned `None`, falling into the `module_files` bucket). `transform_module` parsed the markdown as JS and emitted broken output. The orchestrator forwarded that to tsgo with an unchanged `.svx` virtual path; tsgo failed, the error was swallowed (`eprintln!(\"TypeScript checking failed: ...\")`), no diagnostics surfaced.
3. The summary's `file_count` was actually *files with diagnostics*, not files checked. The combined output `... in 0 files` reasonably read as \"nothing was checked\" — which was true in this case, but for the wrong reason.

## Details

- **`config.rs`** — `file_extensions()` now merges with the native list instead of replacing. Added `unsupported_extensions()` returning user-declared extensions we don't natively handle.
- **`orchestrator.rs`** — After file discovery, partition into supported/unsupported by `SvelteFileKind`. Emit `warning: N files with unregistered extension (.X) skipped` per extension to stderr (grouped, deterministic order, longest-suffix wins for the label so e.g. `.svelte.md` beats `.md`). Unsupported files are excluded from bun, tsgo, and `--list-files`.
- **`output.rs`** — Drop the `====` divider and ` in N files` suffix from the summary when `file_count == 0`, matching [language-tools svelte-check writers.ts:111-141](https://github.com/sveltejs/language-tools/blob/master/packages/svelte-check/src/writers.ts).

### Before / after on the issue's repro

```
$ svelte-check-rs
====================================
svelte-check-rs found 0 errors and 0 warnings in 0 files    # exit 0, silently checked nothing
```

```
$ svelte-check-rs
warning: 2 files with unregistered extension (.svx) skipped
svelte-check-rs found 1 error and 0 warnings in 1 file      # .svelte + +page.ts are checked normally
```

The existing `--ignore '**/*.svx'` workaround still works (skipped files won't be discovered, so no warning fires either).

## Testing

- **Unit tests** (7 new): `file_extensions()` merge behavior, `unsupported_extensions()`, the warning formatter (grouping + longest-suffix label + empty case), and the new clean-summary formatting.
- **Integration tests** (3 new in `tests/integration_extensions.rs`, self-contained temp-dir projects under `target/test-tmp/` using `--list-files --skip-tsgo` so no bun/tsgo install is required):
  - `.svx` files trigger the warning, are excluded from the file list, exit 0.
  - `.svelte.ts` modules are still discovered when the user customizes `extensions`.
  - No warning emitted when only native extensions are present.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and full workspace `cargo test` all pass.