### PR TITLE
perf: cache compiler diagnostics and parallelize checks

### DIFF
--- a/crates/bun-runner/src/runner.rs
+++ b/crates/bun-runner/src/runner.rs
@@ -148,19 +148,19 @@ pub struct BunInput {
     pub options: BunCompileOptions,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BunDiagnosticSeverity {
     Error,
     Warning,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct BunPosition {
     pub line: u32,
     pub column: u32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BunDiagnostic {
     pub file: Utf8PathBuf,
     pub code: String,
@@ -426,33 +426,208 @@ impl BunRunner {
             return Ok(Vec::new());
         }
 
-        let worker_count = self.worker_count.min(inputs.len()).max(1);
-        let mut chunks: Vec<Vec<BunInput>> = vec![Vec::new(); worker_count];
-        for (idx, input) in inputs.into_iter().enumerate() {
-            chunks[idx % worker_count].push(input);
+        let svelte_version = self.resolve_svelte_version();
+        let cache_dir = self.compiler_cache_dir();
+        let mut diagnostics_by_key: HashMap<String, Vec<BunDiagnostic>> = HashMap::new();
+        let mut misses = Vec::new();
+        let mut ordered_keys = Vec::with_capacity(inputs.len());
+
+        for input in inputs {
+            let key = compiler_cache_key(&input, svelte_version.as_deref())?;
+            ordered_keys.push(key.clone());
+            if let Some(cached) = cache_dir
+                .as_ref()
+                .and_then(|dir| read_cached_diagnostics(&dir.join(format!("{key}.json"))))
+            {
+                diagnostics_by_key.insert(key, cached);
+            } else {
+                misses.push((key, input));
+            }
         }
 
-        let mut handles = Vec::new();
-        for chunk in chunks.into_iter().filter(|c| !c.is_empty()) {
-            let bun_path = self.bun_path.clone();
-            let workspace_root = self.workspace_root.clone();
-            let script_path = self.script_path.clone();
-            handles.push(tokio::spawn(async move {
-                let mut worker = BunWorker::spawn(bun_path, workspace_root, script_path).await?;
-                worker.check_batch(chunk).await
-            }));
+        if !misses.is_empty() {
+            let worker_count = self.worker_count.min(misses.len()).max(1);
+            let mut chunks: Vec<Vec<(String, BunInput)>> = vec![Vec::new(); worker_count];
+            for (idx, entry) in misses.into_iter().enumerate() {
+                chunks[idx % worker_count].push(entry);
+            }
+
+            let mut handles = Vec::new();
+            for chunk in chunks.into_iter().filter(|c| !c.is_empty()) {
+                let bun_path = self.bun_path.clone();
+                let workspace_root = self.workspace_root.clone();
+                let script_path = self.script_path.clone();
+                handles.push(tokio::spawn(async move {
+                    let mut key_by_file = HashMap::new();
+                    let inputs: Vec<BunInput> = chunk
+                        .into_iter()
+                        .map(|(key, input)| {
+                            key_by_file.insert(input.filename.clone(), key);
+                            input
+                        })
+                        .collect();
+                    let mut worker =
+                        BunWorker::spawn(bun_path, workspace_root, script_path).await?;
+                    let diagnostics = worker.check_batch(inputs).await?;
+                    Ok::<_, BunError>((key_by_file, diagnostics))
+                }));
+            }
+
+            for handle in handles {
+                let (key_by_file, chunk_diags) = handle
+                    .await
+                    .map_err(|e| BunError::ProtocolError(format!("join error: {e}")))??;
+                for key in key_by_file.values() {
+                    diagnostics_by_key.entry(key.clone()).or_default();
+                }
+                for diag in chunk_diags {
+                    if let Some(key) = key_by_file.get(&diag.file) {
+                        diagnostics_by_key
+                            .entry(key.clone())
+                            .or_default()
+                            .push(diag);
+                    }
+                }
+            }
+
+            if let Some(dir) = &cache_dir {
+                for key in &ordered_keys {
+                    if let Some(diagnostics) = diagnostics_by_key.get(key) {
+                        let _ =
+                            write_cached_diagnostics(&dir.join(format!("{key}.json")), diagnostics);
+                    }
+                }
+            }
         }
 
         let mut diagnostics = Vec::new();
-        for handle in handles {
-            let chunk_diags = handle
-                .await
-                .map_err(|e| BunError::ProtocolError(format!("join error: {e}")))??;
-            diagnostics.extend(chunk_diags);
+        for key in ordered_keys {
+            if let Some(mut cached) = diagnostics_by_key.remove(&key) {
+                diagnostics.append(&mut cached);
+            }
         }
 
         Ok(diagnostics)
     }
+
+    fn compiler_cache_dir(&self) -> Option<Utf8PathBuf> {
+        let cache_base = self
+            .workspace_node_modules_dir()
+            .map(|node_modules| node_modules.join(".cache/svelte-check-rs"))
+            .or_else(Self::get_cache_dir)?;
+        let cache_dir = cache_base
+            .join("compiler-diagnostics")
+            .join(project_cache_namespace(&self.workspace_root));
+        fs::create_dir_all(&cache_dir).ok()?;
+        Some(cache_dir)
+    }
+
+    fn workspace_node_modules_dir(&self) -> Option<Utf8PathBuf> {
+        let mut current = Some(self.workspace_root.as_path());
+        while let Some(dir) = current {
+            let candidate = dir.join("node_modules");
+            if candidate.is_dir() {
+                return Some(candidate);
+            }
+            current = dir.parent();
+        }
+        None
+    }
+
+    fn resolve_svelte_version(&self) -> Option<String> {
+        let mut current = Some(self.workspace_root.as_path());
+        while let Some(dir) = current {
+            let package_json = dir.join("node_modules/svelte/package.json");
+            if let Ok(contents) = fs::read_to_string(&package_json) {
+                if let Ok(value) = serde_json::from_str::<serde_json::Value>(&contents) {
+                    if let Some(version) = value.get("version").and_then(|v| v.as_str()) {
+                        return Some(version.to_string());
+                    }
+                }
+            }
+            current = dir.parent();
+        }
+        None
+    }
+}
+
+fn compiler_cache_key(input: &BunInput, svelte_version: Option<&str>) -> Result<String, BunError> {
+    let options = serde_json::to_vec(&input.options)
+        .map_err(|e| BunError::ProtocolError(format!("failed to serialize options: {e}")))?;
+    let mut hasher = Hasher::new();
+    hasher.update(b"compiler-diagnostics-v1");
+    hasher.update(BUN_SCRIPT_SOURCE.as_bytes());
+    hasher.update(svelte_version.unwrap_or("unknown").as_bytes());
+    hasher.update(input.filename.as_str().as_bytes());
+    hasher.update(&[0]);
+    hasher.update(input.source.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(&options);
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn read_cached_diagnostics(path: &Utf8Path) -> Option<Vec<BunDiagnostic>> {
+    let contents = fs::read(path).ok()?;
+    serde_json::from_slice(&contents).ok()
+}
+
+fn write_cached_diagnostics(
+    path: &Utf8Path,
+    diagnostics: &[BunDiagnostic],
+) -> Result<(), BunError> {
+    let contents = serde_json::to_vec(diagnostics)
+        .map_err(|e| BunError::ProtocolError(format!("failed to serialize cache: {e}")))?;
+    fs::write(path, contents)
+        .map_err(|e| BunError::ProtocolError(format!("failed to write cache: {e}")))?;
+    Ok(())
+}
+
+fn clean_path(path: &Utf8Path) -> Utf8PathBuf {
+    let mut prefix: Option<String> = None;
+    let mut root: Option<String> = None;
+    let mut parts: Vec<String> = Vec::new();
+
+    for component in path.components() {
+        match component {
+            camino::Utf8Component::Prefix(prefix_component) => {
+                prefix = Some(prefix_component.as_str().to_string());
+            }
+            camino::Utf8Component::RootDir => {
+                root = Some(component.as_str().to_string());
+            }
+            camino::Utf8Component::CurDir => {}
+            camino::Utf8Component::ParentDir => {
+                if parts.last().is_some_and(|part| part != "..") {
+                    parts.pop();
+                } else if root.is_none() && prefix.is_none() {
+                    parts.push("..".to_string());
+                } else {
+                    // Already rooted; keep the path normalized at the root.
+                }
+            }
+            camino::Utf8Component::Normal(name) => parts.push(name.to_string()),
+        }
+    }
+
+    let mut out = Utf8PathBuf::new();
+    if let Some(prefix) = prefix {
+        out.push(prefix);
+    }
+    if let Some(root) = root {
+        out.push(root);
+    }
+    for part in parts {
+        out.push(part);
+    }
+    out
+}
+
+fn project_cache_namespace(project_root: &Utf8Path) -> String {
+    Hasher::new()
+        .update(clean_path(project_root).as_str().as_bytes())
+        .finalize()
+        .to_hex()
+        .to_string()
 }
 
 fn find_bun_in_bin(bin: &Utf8Path) -> Option<Utf8PathBuf> {

--- a/crates/bun-runner/src/runner.rs
+++ b/crates/bun-runner/src/runner.rs
@@ -577,8 +577,17 @@ fn write_cached_diagnostics(
 ) -> Result<(), BunError> {
     let contents = serde_json::to_vec(diagnostics)
         .map_err(|e| BunError::ProtocolError(format!("failed to serialize cache: {e}")))?;
-    fs::write(path, contents)
+    // Write through a sibling tmp file and rename so concurrent svelte-check-rs
+    // processes can never observe a partially-written cache entry.
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, contents)
         .map_err(|e| BunError::ProtocolError(format!("failed to write cache: {e}")))?;
+    if let Err(e) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(BunError::ProtocolError(format!(
+            "failed to commit cache: {e}"
+        )));
+    }
     Ok(())
 }
 
@@ -845,5 +854,71 @@ mod tests {
         let options = BunCompileOptions::default();
         assert!(options.runes.is_none());
         assert!(options.experimental.is_none());
+    }
+
+    fn make_input(filename: &str, source: &str) -> BunInput {
+        BunInput {
+            filename: Utf8PathBuf::from(filename),
+            source: source.to_string(),
+            options: BunCompileOptions::default(),
+        }
+    }
+
+    #[test]
+    fn compiler_cache_key_is_stable_for_identical_inputs() {
+        let a = make_input("App.svelte", "<h1>hi</h1>");
+        let b = make_input("App.svelte", "<h1>hi</h1>");
+        let key_a = compiler_cache_key(&a, Some("5.0.0")).unwrap();
+        let key_b = compiler_cache_key(&b, Some("5.0.0")).unwrap();
+        assert_eq!(key_a, key_b);
+    }
+
+    #[test]
+    fn compiler_cache_key_changes_with_source() {
+        let a = make_input("App.svelte", "<h1>hi</h1>");
+        let b = make_input("App.svelte", "<h1>bye</h1>");
+        assert_ne!(
+            compiler_cache_key(&a, Some("5.0.0")).unwrap(),
+            compiler_cache_key(&b, Some("5.0.0")).unwrap()
+        );
+    }
+
+    #[test]
+    fn compiler_cache_key_changes_with_options() {
+        let a = make_input("App.svelte", "<h1>hi</h1>");
+        let mut b = make_input("App.svelte", "<h1>hi</h1>");
+        b.options.runes = Some(true);
+        assert_ne!(
+            compiler_cache_key(&a, Some("5.0.0")).unwrap(),
+            compiler_cache_key(&b, Some("5.0.0")).unwrap()
+        );
+    }
+
+    #[test]
+    fn compiler_cache_key_changes_with_svelte_version() {
+        let input = make_input("App.svelte", "<h1>hi</h1>");
+        assert_ne!(
+            compiler_cache_key(&input, Some("5.0.0")).unwrap(),
+            compiler_cache_key(&input, Some("5.1.0")).unwrap()
+        );
+    }
+
+    #[test]
+    fn compiler_cache_key_distinguishes_missing_version() {
+        let input = make_input("App.svelte", "<h1>hi</h1>");
+        assert_ne!(
+            compiler_cache_key(&input, None).unwrap(),
+            compiler_cache_key(&input, Some("5.0.0")).unwrap()
+        );
+    }
+
+    #[test]
+    fn compiler_cache_key_changes_with_filename() {
+        let a = make_input("a.svelte", "<h1>hi</h1>");
+        let b = make_input("b.svelte", "<h1>hi</h1>");
+        assert_ne!(
+            compiler_cache_key(&a, Some("5.0.0")).unwrap(),
+            compiler_cache_key(&b, Some("5.0.0")).unwrap()
+        );
     }
 }

--- a/crates/svelte-check-rs/src/orchestrator.rs
+++ b/crates/svelte-check-rs/src/orchestrator.rs
@@ -798,6 +798,9 @@ async fn run_single_check(
             transformed_files.add(virtual_path, transformed_file);
         }
         if let Some(input) = result.compiler_input {
+            // Only the JSON formatter (`format_compiler_diagnostics_json`) reads
+            // `compiler_sources` to attach source snippets. The human formatter
+            // does not, so skip the clone to keep peak memory low for large repos.
             if output_json {
                 compiler_sources.insert(input.filename.clone(), input.source.clone());
             }

--- a/crates/svelte-check-rs/src/orchestrator.rs
+++ b/crates/svelte-check-rs/src/orchestrator.rs
@@ -798,7 +798,9 @@ async fn run_single_check(
             transformed_files.add(virtual_path, transformed_file);
         }
         if let Some(input) = result.compiler_input {
-            compiler_sources.insert(input.filename.clone(), input.source.clone());
+            if output_json {
+                compiler_sources.insert(input.filename.clone(), input.source.clone());
+            }
             compiler_inputs.push(input);
         }
     }
@@ -823,12 +825,82 @@ async fn run_single_check(
         }
     }
 
+    let transformed_count = if args.skip_tsgo {
+        0
+    } else {
+        transformed_files.files.len()
+    };
+
+    struct CompilerRun {
+        elapsed: std::time::Duration,
+        result: Result<Vec<BunDiagnostic>, OrchestratorError>,
+    }
+
+    struct TsgoRun {
+        elapsed: std::time::Duration,
+        sync_elapsed: std::time::Duration,
+        sync_ran: bool,
+        result: Result<TsgoCheckOutput, OrchestratorError>,
+    }
+
+    let compiler_future = async {
+        if compiler_inputs.is_empty() {
+            return None;
+        }
+
+        let bun_start = Instant::now();
+        let result = run_bun_check(workspace, compiler_inputs).await;
+        Some(CompilerRun {
+            elapsed: bun_start.elapsed(),
+            result,
+        })
+    };
+
+    let tsgo_future = async {
+        if args.skip_tsgo || transformed_files.files.is_empty() {
+            return None;
+        }
+
+        if let Err(err) = TsgoRunner::ensure_dependency_cache(workspace) {
+            eprintln!("Warning: {}", err);
+        }
+
+        let tsgo_start = Instant::now();
+        let sync_start = Instant::now();
+        let sync_ran = match TsgoRunner::ensure_sveltekit_sync(workspace).await {
+            Ok(ran) => ran,
+            Err(e) => {
+                eprintln!("Warning: {}", e);
+                false
+            }
+        };
+        let sync_elapsed = sync_start.elapsed();
+
+        let result = run_tsgo_check(
+            workspace,
+            &transformed_files,
+            args,
+            args.tsgo_diagnostics,
+            extra_paths,
+        )
+        .await;
+
+        Some(TsgoRun {
+            elapsed: tsgo_start.elapsed(),
+            sync_elapsed,
+            sync_ran,
+            result,
+        })
+    };
+
+    let (compiler_run, tsgo_run) = tokio::join!(compiler_future, tsgo_future);
+
     let mut compiler_total_time = None;
 
-    // Run Svelte compiler diagnostics (bun) if enabled
-    if !compiler_inputs.is_empty() {
-        let bun_start = Instant::now();
-        match run_bun_check(workspace, compiler_inputs).await {
+    // Print Svelte compiler diagnostics first to preserve output ordering.
+    if let Some(run) = compiler_run {
+        compiler_total_time = Some(run.elapsed);
+        match run.result {
             Ok(mut diagnostics) => {
                 apply_compiler_warning_settings(&mut diagnostics, &compiler_warning_settings);
                 diagnostics.retain(|diag| include_compiler_severity(diag.severity, args.threshold));
@@ -861,88 +933,58 @@ async fn run_single_check(
                 eprintln!("Svelte compiler checking failed: {}", e);
             }
         }
-        compiler_total_time = Some(bun_start.elapsed());
     }
 
-    let mut transformed_count = 0usize;
     let mut tsgo_stats: Option<TsgoCheckStats> = None;
     let mut tsgo_total_time = None;
     let mut sveltekit_sync_time = None;
     let mut sveltekit_sync_ran = None;
 
-    // Run TypeScript type-checking if JS diagnostics are enabled and not skipping tsgo
-    if !args.skip_tsgo {
-        let transformed = transformed_files;
-        transformed_count = transformed.files.len();
+    // Then print TypeScript diagnostics, matching the previous phase order.
+    if let Some(run) = tsgo_run {
+        sveltekit_sync_time = Some(run.sync_elapsed);
+        sveltekit_sync_ran = Some(run.sync_ran);
 
-        if !transformed.files.is_empty() {
-            if let Err(err) = TsgoRunner::ensure_dependency_cache(workspace) {
-                eprintln!("Warning: {}", err);
-            }
-            // Ensure SvelteKit types are generated before running tsgo
-            let tsgo_start = Instant::now();
-            let sync_start = Instant::now();
-            let sync_ran = match TsgoRunner::ensure_sveltekit_sync(workspace).await {
-                Ok(ran) => ran,
-                Err(e) => {
-                    eprintln!("Warning: {}", e);
-                    false
-                }
-            };
-            sveltekit_sync_time = Some(sync_start.elapsed());
-            sveltekit_sync_ran = Some(sync_ran);
+        match run.result {
+            Ok(output) => {
+                let mut ts_diagnostics = output.diagnostics;
+                ts_diagnostics.retain(|diag| include_ts_severity(diag.severity, args.threshold));
 
-            match run_tsgo_check(
-                workspace,
-                &transformed,
-                args,
-                args.tsgo_diagnostics,
-                extra_paths,
-            )
-            .await
-            {
-                Ok(output) => {
-                    let mut ts_diagnostics = output.diagnostics;
-                    ts_diagnostics
-                        .retain(|diag| include_ts_severity(diag.severity, args.threshold));
-
-                    // Count and print TypeScript diagnostics
-                    for diag in &ts_diagnostics {
-                        files_with_diagnostics.insert(diag.file.clone());
-                        match diag.severity {
-                            tsgo_runner::DiagnosticSeverity::Error => {
-                                error_count.fetch_add(1, Ordering::Relaxed);
-                            }
-                            tsgo_runner::DiagnosticSeverity::Warning
-                            | tsgo_runner::DiagnosticSeverity::Suggestion => {
-                                warning_count.fetch_add(1, Ordering::Relaxed);
-                            }
+                // Count and print TypeScript diagnostics
+                for diag in &ts_diagnostics {
+                    files_with_diagnostics.insert(diag.file.clone());
+                    match diag.severity {
+                        tsgo_runner::DiagnosticSeverity::Error => {
+                            error_count.fetch_add(1, Ordering::Relaxed);
+                        }
+                        tsgo_runner::DiagnosticSeverity::Warning
+                        | tsgo_runner::DiagnosticSeverity::Suggestion => {
+                            warning_count.fetch_add(1, Ordering::Relaxed);
                         }
                     }
-
-                    // Format and print TypeScript diagnostics
-                    if output_json {
-                        json_output.extend(format_ts_diagnostics_json(&ts_diagnostics, workspace));
-                    } else {
-                        let ts_output =
-                            format_ts_diagnostics(&ts_diagnostics, workspace, args.output);
-                        print!("{}", ts_output);
-                    }
-
-                    tsgo_stats = Some(output.stats);
-                    tsgo_total_time = Some(tsgo_start.elapsed());
                 }
-                Err(e) => {
-                    eprintln!("TypeScript checking failed: {}", e);
+
+                // Format and print TypeScript diagnostics
+                if output_json {
+                    json_output.extend(format_ts_diagnostics_json(&ts_diagnostics, workspace));
+                } else {
+                    let ts_output = format_ts_diagnostics(&ts_diagnostics, workspace, args.output);
+                    print!("{}", ts_output);
                 }
+
+                tsgo_stats = Some(output.stats);
+                tsgo_total_time = Some(run.elapsed);
             }
+            Err(e) => {
+                eprintln!("TypeScript checking failed: {}", e);
+            }
+        }
 
-            if args.tsgo_diagnostics {
-                if let Some(stats) = &tsgo_stats {
-                    if let Some(diag) = &stats.diagnostics {
-                        eprintln!("=== tsgo diagnostics ===");
-                        eprintln!("{}", diag);
-                    }
+        if args.tsgo_diagnostics {
+            if let Some(stats) = &tsgo_stats {
+                if let Some(diag) = &stats.diagnostics {
+                    eprintln!("=== tsgo diagnostics ===");
+                    eprintln!("{}", diag);
                 }
             }
         }

--- a/crates/svelte-transformer/src/transform.rs
+++ b/crates/svelte-transformer/src/transform.rs
@@ -1348,10 +1348,20 @@ declare module "svelte" {
 
     // Get the default props type for SvelteKit route files
     let default_props_type = route_kind.props_type();
-    // Generate template body without function wrapper for embedding in render function
-    let template_body_result = generate_template_body_with_spans(&doc.fragment, false);
-    // Generate template with function wrapper for fallback (template-only components)
-    let template_result = generate_template_check_with_spans(&doc.fragment);
+    let has_instance_script = doc.instance_script.is_some();
+    // Instance-script components embed the template in the render function so
+    // TypeScript control-flow narrowing from the script reaches template checks.
+    let template_body_result = if has_instance_script {
+        Some(generate_template_body_with_spans(&doc.fragment, false))
+    } else {
+        None
+    };
+    // Template-only components still use the standalone wrapper.
+    let template_result = if has_instance_script {
+        None
+    } else {
+        Some(generate_template_check_with_spans(&doc.fragment))
+    };
     let mut template_emitted = false;
 
     // Transform module script if present
@@ -1468,6 +1478,9 @@ declare module "svelte" {
             None
         };
         let mut store_names = rune_result.store_names.clone();
+        let template_body_result = template_body_result
+            .as_ref()
+            .expect("instance-script components should have a template body result");
         for name in &template_body_result.store_names {
             store_names.insert(name.clone());
         }
@@ -1510,7 +1523,7 @@ declare module "svelte" {
             // Emit template body directly in render function scope to preserve control flow narrowing
             if !template_body_result.code.is_empty() {
                 output.push_str(&template_body_result.code);
-                emit_template_with_mappings(&mut builder, &template_body_result);
+                emit_template_with_mappings(&mut builder, template_body_result);
             }
             template_emitted = true;
 
@@ -1575,7 +1588,7 @@ declare module "svelte" {
             // Emit template body directly in render function scope
             if !template_body_result.code.is_empty() {
                 output.push_str(&template_body_result.code);
-                emit_template_with_mappings(&mut builder, &template_body_result);
+                emit_template_with_mappings(&mut builder, template_body_result);
             }
             template_emitted = true;
 
@@ -1600,13 +1613,15 @@ declare module "svelte" {
     }
 
     // Generate template type-check block with span tracking
-    if !template_emitted && !template_result.code.is_empty() {
-        // Use the structured template code which properly handles component props,
-        // object literals, and control flow structures
-        output.push_str(&template_result.code);
+    if let Some(template_result) = template_result.as_ref() {
+        if !template_emitted && !template_result.code.is_empty() {
+            // Use the structured template code which properly handles component props,
+            // object literals, and control flow structures
+            output.push_str(&template_result.code);
 
-        // Emit template code with proper source mappings for expressions
-        emit_template_with_mappings(&mut builder, &template_result);
+            // Emit template code with proper source mappings for expressions
+            emit_template_with_mappings(&mut builder, template_result);
+        }
     }
 
     // Generate component export

--- a/crates/svelte-transformer/src/transform.rs
+++ b/crates/svelte-transformer/src/transform.rs
@@ -1348,20 +1348,6 @@ declare module "svelte" {
 
     // Get the default props type for SvelteKit route files
     let default_props_type = route_kind.props_type();
-    let has_instance_script = doc.instance_script.is_some();
-    // Instance-script components embed the template in the render function so
-    // TypeScript control-flow narrowing from the script reaches template checks.
-    let template_body_result = if has_instance_script {
-        Some(generate_template_body_with_spans(&doc.fragment, false))
-    } else {
-        None
-    };
-    // Template-only components still use the standalone wrapper.
-    let template_result = if has_instance_script {
-        None
-    } else {
-        Some(generate_template_check_with_spans(&doc.fragment))
-    };
     let mut template_emitted = false;
 
     // Transform module script if present
@@ -1477,10 +1463,10 @@ declare module "svelte" {
         } else {
             None
         };
+        // Instance-script components embed the template in the render function so
+        // TypeScript control-flow narrowing from the script reaches template checks.
+        let template_body_result = generate_template_body_with_spans(&doc.fragment, false);
         let mut store_names = rune_result.store_names.clone();
-        let template_body_result = template_body_result
-            .as_ref()
-            .expect("instance-script components should have a template body result");
         for name in &template_body_result.store_names {
             store_names.insert(name.clone());
         }
@@ -1523,7 +1509,7 @@ declare module "svelte" {
             // Emit template body directly in render function scope to preserve control flow narrowing
             if !template_body_result.code.is_empty() {
                 output.push_str(&template_body_result.code);
-                emit_template_with_mappings(&mut builder, template_body_result);
+                emit_template_with_mappings(&mut builder, &template_body_result);
             }
             template_emitted = true;
 
@@ -1588,7 +1574,7 @@ declare module "svelte" {
             // Emit template body directly in render function scope
             if !template_body_result.code.is_empty() {
                 output.push_str(&template_body_result.code);
-                emit_template_with_mappings(&mut builder, template_body_result);
+                emit_template_with_mappings(&mut builder, &template_body_result);
             }
             template_emitted = true;
 
@@ -1612,15 +1598,17 @@ declare module "svelte" {
         }
     }
 
-    // Generate template type-check block with span tracking
-    if let Some(template_result) = template_result.as_ref() {
-        if !template_emitted && !template_result.code.is_empty() {
+    // Template-only components use the standalone wrapper. Skip this when the
+    // instance-script branch above already emitted the template inline.
+    if !template_emitted {
+        let template_result = generate_template_check_with_spans(&doc.fragment);
+        if !template_result.code.is_empty() {
             // Use the structured template code which properly handles component props,
             // object literals, and control flow structures
             output.push_str(&template_result.code);
 
             // Emit template code with proper source mappings for expressions
-            emit_template_with_mappings(&mut builder, template_result);
+            emit_template_with_mappings(&mut builder, &template_result);
         }
     }
 

--- a/crates/tsgo-runner/src/parser.rs
+++ b/crates/tsgo-runner/src/parser.rs
@@ -231,6 +231,13 @@ fn strip_cache_prefix(path: &str) -> Option<String> {
         if let Some(idx) = normalized.find(marker) {
             let rel = &normalized[idx + marker.len()..];
             if !rel.is_empty() {
+                if marker == "/node_modules/.cache/svelte-check-rs/" {
+                    if let Some((_, project_rel)) = rel.split_once('/') {
+                        if !project_rel.is_empty() {
+                            return Some(project_rel.to_string());
+                        }
+                    }
+                }
                 return Some(rel.to_string());
             }
         }
@@ -300,5 +307,14 @@ mod tests {
         let files = TransformedFiles::new();
         let diagnostics = parse_tsgo_output("", &files).unwrap();
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_strip_cache_prefix_skips_project_namespace() {
+        let path = "/repo/node_modules/.cache/svelte-check-rs/abcdef/src/App.svelte.ts";
+        assert_eq!(
+            strip_cache_prefix(path),
+            Some("src/App.svelte.ts".to_string())
+        );
     }
 }

--- a/crates/tsgo-runner/src/runner.rs
+++ b/crates/tsgo-runner/src/runner.rs
@@ -1002,7 +1002,7 @@ impl TsgoRunner {
         let allow_js = snapshot
             .allow_js
             .unwrap_or(snapshot.check_js.unwrap_or(false));
-        let extra_files: Vec<&Utf8PathBuf> = if allow_js {
+        let mut extra_files: Vec<&Utf8PathBuf> = if allow_js {
             options.extra_files.iter().collect()
         } else {
             options
@@ -1011,6 +1011,8 @@ impl TsgoRunner {
                 .filter(|path| !is_js_like_file(path))
                 .collect()
         };
+        extra_files.sort();
+        extra_files.dedup();
         if !extra_files.is_empty() {
             root.insert(
                 "files".to_string(),


### PR DESCRIPTION
## Summary
- Run Svelte compiler diagnostics and tsgo concurrently after the Rust parse/transform phase.
- Cache Svelte compiler diagnostics by source/options/Svelte version to avoid recompiling unchanged components.
- Reduce repeated work by skipping duplicate template generation, stabilizing tsgo overlay file ordering, and fixing cache-path diagnostic lookup.

## Details
- Keeps compiler diagnostics cache outside the tsgo project cache root so dependency cache invalidation cannot race with the parallel compiler phase.
- Preserves diagnostic output ordering by collecting compiler and tsgo results concurrently, then formatting compiler diagnostics before TypeScript diagnostics.
- Adds a tsgo path normalization test for namespaced cache paths.

## Testing
- `hyperfine --warmup 3 --runs 12` on `test-fixtures/projects/sveltekit-bundler`: full warm check improved from `210.3 ms ± 1.7 ms` to `97.4 ms ± 1.8 ms`; `--skip-tsgo` warm check improved from `124.2 ms ± 1.3 ms` to `9.0 ms ± 0.5 ms`.
- `cargo test -p bun-runner -p tsgo-runner -p svelte-transformer`
- `cargo test -p svelte-check-rs`
- `cargo clippy --all-targets -- -D warnings`