### PR TITLE
fix(parser): handle single-quoted and unquoted attrs on <script>/<style>

### DIFF
--- a/crates/svelte-check-rs/tests/integration_issues.rs
+++ b/crates/svelte-check-rs/tests/integration_issues.rs
@@ -1742,3 +1742,54 @@ fn test_issue_121_experimental_async_respected_by_compiler() {
 
     assert_no_diagnostics_in_file(&diagnostics, "issue-121-experimental-async/+page.svelte");
 }
+
+// ============================================================================
+// ISSUE #132: <script> with single-quoted attribute values
+// ============================================================================
+//
+// Before the fix, `<script lang='ts'>` (single-quoted attr) caused
+// `parse_script` to bail silently, letting the script body leak into the
+// template parser. Symptoms:
+//   - `$bindable()` inside `$props()` destructure → false-positive
+//     `invalid-rune-usage` diagnostic.
+//   - TS generics like `ZodInfer<typeof schema>` → false-positive
+//     `mismatched closing tag: expected </typeof>, found </script>` parse error.
+//
+// Fixture: src/routes/issue-132-single-quote-script/{Modal.svelte,+page.svelte}
+#[test]
+fn test_issue_132_single_quoted_script_attr_modal_no_errors() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let (_exit_code, diagnostics) = run_check_json(&fixture_path);
+
+    // Guard against the parse-error / invalid-rune-usage regression specifically.
+    let svelte_diagnostics = filter_diagnostics_by_source(&diagnostics, "svelte");
+    assert_no_diagnostics_in_file(
+        &svelte_diagnostics,
+        "issue-132-single-quote-script/Modal.svelte",
+    );
+
+    // Belt-and-suspenders: no TS-side fallout from the body being misparsed.
+    let ts_diagnostics = filter_diagnostics_by_source(&diagnostics, "ts");
+    assert_no_diagnostics_in_file(
+        &ts_diagnostics,
+        "issue-132-single-quote-script/Modal.svelte",
+    );
+}
+
+#[test]
+fn test_issue_132_single_quoted_script_attr_ts_generics_no_errors() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let (_exit_code, diagnostics) = run_check_json(&fixture_path);
+
+    let svelte_diagnostics = filter_diagnostics_by_source(&diagnostics, "svelte");
+    assert_no_diagnostics_in_file(
+        &svelte_diagnostics,
+        "issue-132-single-quote-script/+page.svelte",
+    );
+
+    let ts_diagnostics = filter_diagnostics_by_source(&diagnostics, "ts");
+    assert_no_diagnostics_in_file(
+        &ts_diagnostics,
+        "issue-132-single-quote-script/+page.svelte",
+    );
+}

--- a/crates/svelte-parser/src/parser.rs
+++ b/crates/svelte-parser/src/parser.rs
@@ -960,6 +960,32 @@ impl<'src> Parser<'src> {
         ""
     }
 
+    /// Parses an attribute value inside a `<script>` or `<style>` opening tag.
+    /// Accepts double-quoted, single-quoted, and unquoted values; expression
+    /// values (`{...}`) are not supported on these section tags.
+    fn parse_section_tag_attribute_value(&mut self) -> AttributeValue {
+        if self.eat(TokenKind::DoubleQuote) {
+            let (text, span) = self.read_until(&["\""]);
+            self.eat(TokenKind::DoubleQuote);
+            AttributeValue::Text(TextValue { span, value: text })
+        } else if self.eat(TokenKind::SingleQuote) {
+            let (text, span) = self.read_until(&["'"]);
+            self.eat(TokenKind::SingleQuote);
+            AttributeValue::Text(TextValue { span, value: text })
+        } else if self.check(TokenKind::Ident)
+            || self.check(TokenKind::Script)
+            || self.check(TokenKind::Style)
+            || self.check(TokenKind::Number)
+        {
+            let span = self.current().span;
+            let text = self.current_text().to_string();
+            self.advance();
+            AttributeValue::Text(TextValue { span, value: text })
+        } else {
+            AttributeValue::True
+        }
+    }
+
     /// Parses a script block.
     fn parse_script(&mut self) -> Option<Script> {
         let start = self.current().span.start;
@@ -983,7 +1009,10 @@ impl<'src> Parser<'src> {
         loop {
             self.skip_whitespace();
 
-            if self.check(TokenKind::RAngle) || self.check(TokenKind::SlashRAngle) {
+            if self.check(TokenKind::RAngle)
+                || self.check(TokenKind::SlashRAngle)
+                || self.check(TokenKind::Eof)
+            {
                 break;
             }
 
@@ -993,13 +1022,7 @@ impl<'src> Parser<'src> {
                 self.advance();
 
                 let value = if self.eat(TokenKind::Eq) {
-                    if self.eat(TokenKind::DoubleQuote) {
-                        let (text, span) = self.read_until(&["\""]);
-                        self.eat(TokenKind::DoubleQuote);
-                        AttributeValue::Text(TextValue { span, value: text })
-                    } else {
-                        AttributeValue::True
-                    }
+                    self.parse_section_tag_attribute_value()
                 } else {
                     AttributeValue::True
                 };
@@ -1037,14 +1060,21 @@ impl<'src> Parser<'src> {
                     value,
                 }));
             } else {
-                break;
+                // Unknown token inside the opening tag — skip it so we don't bail
+                // and silently leak the script body into the template parser.
+                self.advance();
             }
         }
 
-        // Expect `>`
-        if !self.eat(TokenKind::RAngle) {
-            return None;
+        // Skip forward to `>` (or EOF) so a malformed opening tag doesn't cause
+        // the script body to be parsed as template content.
+        while !self.check(TokenKind::RAngle)
+            && !self.check(TokenKind::SlashRAngle)
+            && !self.check(TokenKind::Eof)
+        {
+            self.advance();
         }
+        let _ = self.eat(TokenKind::RAngle) || self.eat(TokenKind::SlashRAngle);
 
         // Read content until </script>
         let content_start = self.current().span.start;
@@ -1098,7 +1128,10 @@ impl<'src> Parser<'src> {
         loop {
             self.skip_whitespace();
 
-            if self.check(TokenKind::RAngle) || self.check(TokenKind::SlashRAngle) {
+            if self.check(TokenKind::RAngle)
+                || self.check(TokenKind::SlashRAngle)
+                || self.check(TokenKind::Eof)
+            {
                 break;
             }
 
@@ -1108,13 +1141,7 @@ impl<'src> Parser<'src> {
                 self.advance();
 
                 let value = if self.eat(TokenKind::Eq) {
-                    if self.eat(TokenKind::DoubleQuote) {
-                        let (text, span) = self.read_until(&["\""]);
-                        self.eat(TokenKind::DoubleQuote);
-                        AttributeValue::Text(TextValue { span, value: text })
-                    } else {
-                        AttributeValue::True
-                    }
+                    self.parse_section_tag_attribute_value()
                 } else {
                     AttributeValue::True
                 };
@@ -1135,14 +1162,21 @@ impl<'src> Parser<'src> {
                     value,
                 }));
             } else {
-                break;
+                // Unknown token inside the opening tag — skip it so we don't bail
+                // and silently leak the style body into the template parser.
+                self.advance();
             }
         }
 
-        // Expect `>`
-        if !self.eat(TokenKind::RAngle) {
-            return None;
+        // Skip forward to `>` (or EOF) so a malformed opening tag doesn't cause
+        // the style body to be parsed as template content.
+        while !self.check(TokenKind::RAngle)
+            && !self.check(TokenKind::SlashRAngle)
+            && !self.check(TokenKind::Eof)
+        {
+            self.advance();
         }
+        let _ = self.eat(TokenKind::RAngle) || self.eat(TokenKind::SlashRAngle);
 
         // Read content until </style>
         let content_start = self.current().span.start;
@@ -2892,6 +2926,78 @@ mod tests {
 
         let script = result.document.instance_script.unwrap();
         assert!(script.content.contains("let x = 1"));
+    }
+
+    /// Issue #132: `<script lang='ts'>` (single-quoted attr) used to fail
+    /// silently — `parse_script` returned `None`, the body leaked into the
+    /// template parser, and runes like `$bindable()` got flagged as invalid
+    /// template expressions.
+    #[test]
+    fn test_parse_script_single_quoted_lang() {
+        let source = "<script lang='ts'>let x = 1;</script>";
+        let result = Parser::new(source, ParseOptions::default()).parse();
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+        let script = result
+            .document
+            .instance_script
+            .expect("instance script should be recognized with single-quoted lang attr");
+        assert!(matches!(script.lang, ScriptLang::TypeScript));
+        assert!(script.content.contains("let x = 1"));
+        assert_eq!(script.attributes.len(), 1);
+        match &script.attributes[0] {
+            Attribute::Normal(attr) => {
+                assert_eq!(attr.name, "lang");
+                match &attr.value {
+                    AttributeValue::Text(t) => assert_eq!(t.value, "ts"),
+                    other => panic!("expected Text attr value, got {:?}", other),
+                }
+            }
+            other => panic!("expected normal attribute, got {:?}", other),
+        }
+    }
+
+    /// Issue #132: TS generics like `ZodInfer<typeof schema>` inside a script
+    /// with single-quoted attrs used to surface as `mismatched closing tag:
+    /// expected </typeof>` because the body was being parsed as template.
+    #[test]
+    fn test_parse_script_single_quoted_lang_with_ts_generics() {
+        let source = "<script lang='ts'>\
+            type Form = ZodInfer<typeof schema>;\
+            </script>";
+        let result = Parser::new(source, ParseOptions::default()).parse();
+        assert!(
+            result.errors.is_empty(),
+            "TS generics in script body should not produce parse errors: {:?}",
+            result.errors
+        );
+        let script = result.document.instance_script.expect("script recognized");
+        assert!(script.content.contains("ZodInfer<typeof schema>"));
+    }
+
+    #[test]
+    fn test_parse_script_unquoted_lang() {
+        let source = "<script lang=ts>let x = 1;</script>";
+        let result = Parser::new(source, ParseOptions::default()).parse();
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+        let script = result.document.instance_script.expect("script recognized");
+        assert!(matches!(script.lang, ScriptLang::TypeScript));
+        assert!(script.content.contains("let x = 1"));
+    }
+
+    #[test]
+    fn test_parse_style_single_quoted_attr() {
+        let source = "<style lang='scss'>.a { color: red; }</style>";
+        let result = Parser::new(source, ParseOptions::default()).parse();
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+        let style = result
+            .document
+            .style
+            .expect("style should be recognized with single-quoted lang attr");
+        assert!(style.content.contains(".a"));
+        assert_eq!(style.attributes.len(), 1);
     }
 
     #[test]

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-132-single-quote-script/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-132-single-quote-script/+page.svelte
@@ -1,0 +1,23 @@
+<script lang='ts'>
+  type ZodInfer<T> = T extends { _output: infer O } ? O : never;
+
+  function object<T>(_shape: T): { _output: T } {
+    return null as any;
+  }
+  function string(): { _output: string } {
+    return null as any;
+  }
+
+  const z = { object, string };
+
+  const schema = z.object({
+    username: z.string(),
+    password: z.string()
+  });
+
+  type Form = ZodInfer<typeof schema>;
+
+  let form = $state<Form | null>(null);
+</script>
+
+<pre>{JSON.stringify(form)}</pre>

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-132-single-quote-script/Modal.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-132-single-quote-script/Modal.svelte
@@ -1,0 +1,25 @@
+<script lang='ts'>
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    isOpen: boolean;
+    children: Snippet;
+    title?: string;
+    onAction?: () => void;
+  }
+
+  let {
+    isOpen = $bindable(),
+    children,
+    title,
+    onAction
+  }: Props = $props();
+</script>
+
+{#if isOpen}
+  <div>
+    {#if title}<h2>{title}</h2>{/if}
+    {@render children()}
+    {#if onAction}<button onclick={onAction}>Go</button>{/if}
+  </div>
+{/if}


### PR DESCRIPTION
## Summary

Fixes #132. `parse_script` and `parse_style` only matched double-quoted attribute values, so `<script lang='ts'>` (single quotes) caused the parser to silently bail out — `parse_script` returned `None` and the script body leaked into the template parser. The two errors reported in the issue are both downstream symptoms of this single root cause.

## Details

When the parser sees `<` `script`, it commits to parsing a `<script>` tag. Before this PR, any unexpected token inside the opening tag (most commonly `'` instead of `\"` around a `lang` value) would cause `parse_script` to return `None`. The document parser then fell through to `parse_template_node`, which tried to interpret the would-be script body as template content. From there:

- `$bindable()` inside `let { isOpen = $bindable() } = $props()` ended up inside a `{...}` expression tag, where `crates/svelte-diagnostics/src/component/mod.rs` correctly flags any rune call → false positive `invalid-rune-usage` error.
- `ZodInfer<typeof schema>` was tokenized as an HTML element `<typeof schema>`, and the subsequent `</script>` became a `mismatched closing tag: expected </typeof>` parse error.

### Fix

- New shared helper `parse_section_tag_attribute_value` accepts **double-quoted**, **single-quoted**, and **unquoted** attribute values. (Expression values `{...}` are not supported on `<script>`/`<style>`, matching prior behavior.)
- `parse_script` and `parse_style` now use the helper, and skip any unrecognized tokens inside the opening tag instead of bailing out. After the attribute loop they scan forward to `>` (or EOF), so even an arbitrarily malformed opening tag won't cause the body to be misparsed as template content.

## Why

False-positive `invalid-rune-usage` and `mismatched closing tag` errors block users whose project formatter (e.g. Prettier with `singleQuote: true`) emits `<script lang='ts'>`. Beyond that, the silent-bail-out pattern made any future malformed-opening-tag bug class also produce confusing template parser cascades — the defensive fix prevents that whole class of regressions.

## Testing

- **Unit tests** (`crates/svelte-parser/src/parser.rs`, in-source `mod tests`):
  - `test_parse_script_single_quoted_lang` — `<script lang='ts'>` recognized, lang detected, attribute round-trips.
  - `test_parse_script_single_quoted_lang_with_ts_generics` — `ZodInfer<typeof schema>` inside script body produces no parse errors.
  - `test_parse_script_unquoted_lang` — `<script lang=ts>` recognized.
  - `test_parse_style_single_quoted_attr` — `<style lang='scss'>` recognized.
- **Integration tests** (`crates/svelte-check-rs/tests/integration_issues.rs`):
  - `test_issue_132_single_quoted_script_attr_modal_no_errors` — replays the user's `Modal.svelte` (`$bindable()` case) and asserts zero svelte + zero ts diagnostics.
  - `test_issue_132_single_quoted_script_attr_ts_generics_no_errors` — replays the user's `+page.svelte` (`typeof` case) and asserts the same.
- Full `cargo test` suite passes (~736 tests, 0 failures).
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.

## Test plan

- [x] New unit tests pass
- [x] New integration tests pass
- [x] Full test suite passes
- [x] Clippy clean
- [x] Formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)