### PR TITLE
fix(tsgo): absolutize tsconfig paths per defining ancestor

### DIFF
--- a/crates/svelte-check-rs/tests/integration_tsconfig.rs
+++ b/crates/svelte-check-rs/tests/integration_tsconfig.rs
@@ -204,6 +204,16 @@ fn run_check_json_internal(
     fixture_name: &str,
     emit_ts: bool,
 ) -> (i32, Vec<JsonDiagnostic>, String) {
+    run_check_json_with_args(fixture_name, emit_ts, &[])
+}
+
+/// Like `run_check_json_internal` but lets the caller append extra CLI args
+/// (e.g. `--tsconfig tsconfig.array.json`) without forking the whole helper.
+fn run_check_json_with_args(
+    fixture_name: &str,
+    emit_ts: bool,
+    extra_args: &[&str],
+) -> (i32, Vec<JsonDiagnostic>, String) {
     let _lock = lock_fixture(fixture_name);
 
     // Map fixture name to its ready flag
@@ -230,6 +240,7 @@ fn run_check_json_internal(
         .args(if emit_ts { vec!["--emit-ts"] } else { vec![] })
         .arg("--output")
         .arg("json")
+        .args(extra_args)
         .output()
         .expect("Failed to execute svelte-check-rs");
 
@@ -1524,4 +1535,48 @@ fn test_issue_7_use_directive_member_access() {
         "REGRESSION (issue #7): Type checking should work for use directives with member access.\n\
          Expected TypeScript errors for intentional type mismatches."
     );
+}
+
+// ============================================================================
+// EXTENDS-ARRAY TSCONFIG TESTS (Issue #140)
+// ============================================================================
+// `tsconfig.array.json` lives next to `tsconfig.json` in the sveltekit-bundler
+// fixture and uses the TS 5.0+ `extends: [...]` array form. Before #141, this
+// caused `load_tsconfig_snapshot_inner` to silently drop the entire extends
+// chain — emptying `compilerOptions.paths` — so every `$lib/...` import in the
+// fixture would fail with TS2307. The test below feeds the array tsconfig
+// through `--tsconfig` and asserts diagnostics stay byte-identical to the
+// canonical single-string run.
+
+#[test]
+#[serial]
+fn test_bundler_extends_array_no_module_resolution_errors() {
+    let (_exit_code, diagnostics, _stderr) = run_check_json_with_args(
+        "sveltekit-bundler",
+        false,
+        &["--tsconfig", "tsconfig.array.json"],
+    );
+    let diagnostics = filter_diagnostics_by_source(&diagnostics, "ts");
+
+    // Before #141, every `$lib/...` import in the fixture would fail with
+    // TS2307 because the extends-array snapshot was empty. The repro is loud:
+    // a single regression here floods diagnostics with thousands of these.
+    assert_no_resolution_errors(&diagnostics);
+}
+
+#[test]
+#[serial]
+fn test_bundler_extends_array_matches_single_string_errors() {
+    let (exit_code, diagnostics, _stderr) = run_check_json_with_args(
+        "sveltekit-bundler",
+        false,
+        &["--tsconfig", "tsconfig.array.json"],
+    );
+    let diagnostics = filter_diagnostics_by_source(&diagnostics, "ts");
+
+    // Semantic equivalence: the array form `["./.svelte-kit/tsconfig.json"]`
+    // must produce the exact same diagnostics as the string form
+    // `"./.svelte-kit/tsconfig.json"` that the rest of the suite asserts on.
+    assert_exact_errors(&diagnostics, &bundler_expected_errors());
+    assert_ne!(exit_code, 0, "Expected non-zero exit code due to errors");
 }

--- a/crates/tsgo-runner/src/runner.rs
+++ b/crates/tsgo-runner/src/runner.rs
@@ -837,11 +837,25 @@ impl TsgoRunner {
                 snapshot.root_dirs_base = tsconfig_path.parent().map(|p| p.to_owned());
             }
             if let Some(paths) = options.get("paths").and_then(Value::as_object) {
-                snapshot.paths_base = tsconfig_path.parent().map(|p| p.to_owned());
+                // Absolutize each entry against THIS tsconfig's parent dir so
+                // that paths inherited from an extends chain keep their
+                // defining tsconfig's base. Storing relative strings with a
+                // single shared `paths_base` would silently mis-resolve
+                // ancestor paths once the leaf (or a later array entry)
+                // defines its own paths block.
+                let parent = tsconfig_path.parent();
+                snapshot.paths_base = parent.map(|p| p.to_owned());
                 for (key, value) in paths {
                     if let Some(entries) = parse_string_array(Some(value)) {
                         if !entries.is_empty() {
-                            snapshot.paths.insert(key.clone(), entries);
+                            let resolved_entries: Vec<String> = match parent {
+                                Some(base) => entries
+                                    .into_iter()
+                                    .map(|e| resolve_path_value(base, &e))
+                                    .collect(),
+                                None => entries,
+                            };
+                            snapshot.paths.insert(key.clone(), resolved_entries);
                         }
                     }
                 }
@@ -2439,9 +2453,14 @@ mod tests {
         );
         let snapshot = runner.load_tsconfig_snapshot(&tsconfig_path);
 
+        // Paths are stored absolute (resolved against the defining tsconfig's
+        // dir) so that an extends chain with multiple paths-defining ancestors
+        // doesn't share a single mis-pointed base. The expected value is the
+        // absolutized form of `./from-b` relative to the temp root.
+        let expected = resolve_path_value(&temp_root, "./from-b");
         assert_eq!(
             snapshot.paths.get("$dup").map(Vec::as_slice),
-            Some(["./from-b".to_string()].as_slice()),
+            Some([expected].as_slice()),
             "later array entry must override earlier entry's path for the same key"
         );
     }
@@ -2478,9 +2497,10 @@ mod tests {
         );
         let snapshot = runner.load_tsconfig_snapshot(&tsconfig_path);
 
+        let expected = resolve_path_value(&temp_root, "./local");
         assert_eq!(
             snapshot.paths.get("$lib").map(Vec::as_slice),
-            Some(["./local".to_string()].as_slice()),
+            Some([expected].as_slice()),
             "current tsconfig's paths must override inherited paths"
         );
     }

--- a/test-fixtures/projects/sveltekit-bundler/tsconfig.array.json
+++ b/test-fixtures/projects/sveltekit-bundler/tsconfig.array.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["./.svelte-kit/tsconfig.json"],
+	"compilerOptions": {
+		"rewriteRelativeImportExtensions": true,
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"moduleResolution": "bundler",
+		"paths": {
+			"$unused-alias": ["./src/lib"]
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #141. That PR closed the array-extends snapshot reader hole, but `TsconfigSnapshot` still stored a single shared `paths_base`. When multiple tsconfigs in an extends chain (array or nested) each defined a `paths` block, every inherited entry got re-resolved against the last paths-defining tsconfig's dir — so a relative entry like `"$lib": ["../src/lib"]` from `.svelte-kit/tsconfig.json` ended up joined to the project root instead of the `.svelte-kit/` dir, yielding paths like `<project>/../src/lib` and TS2307 errors.

## Details

Absolutize each entry at read time, against the parent dir of the tsconfig that defined it. `resolve_path_value` is a no-op on absolute values, so the existing overlay/extras-merge logic keeps working unchanged.

The previous PR called this out as an "out-of-scope" limitation; the new integration test made it unavoidable.

## Test fixtures

- **`test-fixtures/projects/sveltekit-bundler/tsconfig.array.json`** — alt tsconfig that uses array-extends AND defines its own `paths` block. The local `paths` block is required to trigger the bug; without it, tsgo's own extends-array support papers over our empty snapshot via the overlay's `extends` chain (and the integration test wouldn't catch a regression).
- Two new tests in `integration_tsconfig.rs` run the binary with `--tsconfig tsconfig.array.json` and assert no module-resolution errors + exact diagnostic parity with the canonical single-string run.
- Two existing unit tests updated to compare absolute paths instead of relative strings.

## Validation

- [x] `cargo test` (full workspace): all green
- [x] `cargo clippy --all-targets -- -D warnings`: clean
- [x] `cargo fmt --all --check`: clean
- [x] Ran the release binary against all 4 careswitch SvelteKit apps (careswitch-web, careswitch-marketing, forge-web, rcm-web) — 0 errors in each, identical to the single-string-extends baseline.
- [x] Confirmed the integration tests fail without the per-entry fix and pass with it.

Refs #140 (reopened)