### PR TITLE
fix: address issues #143–#146 (each-without-item, dup $types, children Snippet, module placeholders)

### DIFF
--- a/crates/svelte-check-rs/tests/integration_issues.rs
+++ b/crates/svelte-check-rs/tests/integration_issues.rs
@@ -2095,3 +2095,33 @@ fn test_issue_146_transformed_output_preserves_unknown_aliases() {
         content
     );
 }
+// ============================================================================
+// ISSUE #145: UNTYPED `children` PROP INFERRED AS `unknown` INSTEAD OF `Snippet`
+// ============================================================================
+// `let { children } = $props()` with no annotation should still let
+// `{@render children?.()}` type-check, because `svelte-check` contextually
+// infers `children` (and other slot/snippet names) as optional Snippets. Our
+// transformer was widening to `Record<string, unknown>`, so `children` came
+// back as `unknown`, and tsgo reported TS2349 "This expression is not callable".
+//
+// Fixture: src/lib/issue-145-untyped-children.svelte
+//   Line 2: let { children } = $props();
+//   Line 6: {@render children?.()}
+#[test]
+fn test_issue_145_untyped_children_is_callable() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let (_exit_code, diagnostics) = run_check_json(&fixture_path);
+    let ts_diagnostics = filter_diagnostics_by_source(&diagnostics, "ts");
+
+    let not_callable: Vec<_> = ts_diagnostics
+        .iter()
+        .filter(|d| d.filename.ends_with("issue-145-untyped-children.svelte") && d.code == "TS2349")
+        .collect();
+    assert!(
+        not_callable.is_empty(),
+        "Issue #145: untyped `children` prop was not inferred as a Snippet:\n{:#?}",
+        not_callable
+    );
+
+    assert_no_diagnostics_in_file(&ts_diagnostics, "issue-145-untyped-children.svelte");
+}

--- a/crates/svelte-check-rs/tests/integration_issues.rs
+++ b/crates/svelte-check-rs/tests/integration_issues.rs
@@ -1941,3 +1941,39 @@ fn test_issue_136_transformed_output_not_garbled() {
         assert_props_lhs_transform_is_valid(&content, name);
     }
 }
+
+// ============================================================================
+// ISSUE #143: EACH BLOCKS WITHOUT AN ITEM ({#each iterable, i})
+// ============================================================================
+// Svelte supports `{#each iterable, i}` to render N items without a value
+// binding (https://svelte.dev/docs/svelte/each#Each-blocks-without-an-item).
+// The transformer was emitting `const __each_0 = iterable, i;` (parsing the
+// comma as a JS declaration list) and `for (const  of __each_0)` (empty
+// iterator variable), which tsgo rejected with TS1155 / TS7005 / TS1123.
+//
+// Fixture: src/routes/issue-143-each-no-item/+page.svelte
+//   Line 7: {#each { length: count }, i}     (count-driven length)
+//   Line 11: {#each { length: 3 }, j}        (literal length)
+#[test]
+fn test_issue_143_each_without_item_no_ts_errors() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let (_exit_code, diagnostics) = run_check_json(&fixture_path);
+    let ts_diagnostics = filter_diagnostics_by_source(&diagnostics, "ts");
+
+    // Specific guard against the broken-transform error shape.
+    let each_errors: Vec<_> = ts_diagnostics
+        .iter()
+        .filter(|d| {
+            d.filename.ends_with("issue-143-each-no-item/+page.svelte")
+                && (d.code == "TS1155" || d.code == "TS1123" || d.code == "TS7005")
+        })
+        .collect();
+    assert!(
+        each_errors.is_empty(),
+        "Issue #143: item-less each block produced TS parse/init errors:\n{:#?}",
+        each_errors
+    );
+
+    // No other TS errors should land in this fixture either.
+    assert_no_diagnostics_in_file(&ts_diagnostics, "issue-143-each-no-item/+page.svelte");
+}

--- a/crates/svelte-check-rs/tests/integration_issues.rs
+++ b/crates/svelte-check-rs/tests/integration_issues.rs
@@ -1977,3 +1977,62 @@ fn test_issue_143_each_without_item_no_ts_errors() {
     // No other TS errors should land in this fixture either.
     assert_no_diagnostics_in_file(&ts_diagnostics, "issue-143-each-no-item/+page.svelte");
 }
+
+// ============================================================================
+// ISSUE #144: DUPLICATE PAGEPROPS IMPORT (./$types import hoisted but original
+// not stripped from the render body)
+// ============================================================================
+// When a `+page.svelte` did `import type { PageProps } from "./$types"` and
+// then `let { data }: PageProps = $props()`, the transformer hoisted the
+// `import type` to module scope *and* left the original import in
+// `__svelte_render`, producing two `TS2300 Duplicate identifier 'PageProps'`.
+//
+// Fixture: src/routes/issue-144-duplicate-pageprops/{+page.server.ts,+page.svelte}
+//   Line 2: import type { PageProps } from "./$types";
+//   Line 3: let { data }: PageProps = $props();
+#[test]
+fn test_issue_144_no_duplicate_pageprops_identifier() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let (_exit_code, diagnostics) = run_check_json(&fixture_path);
+    let ts_diagnostics = filter_diagnostics_by_source(&diagnostics, "ts");
+
+    let duplicate_errors: Vec<_> = ts_diagnostics
+        .iter()
+        .filter(|d| {
+            d.filename
+                .ends_with("issue-144-duplicate-pageprops/+page.svelte")
+                && d.code == "TS2300"
+                && d.message.contains("PageProps")
+        })
+        .collect();
+    assert!(
+        duplicate_errors.is_empty(),
+        "Issue #144: hoisted PageProps import left a duplicate behind:\n{:#?}",
+        duplicate_errors
+    );
+
+    // Belt-and-suspenders: nothing else should fail on this fixture.
+    assert_no_diagnostics_in_file(
+        &ts_diagnostics,
+        "issue-144-duplicate-pageprops/+page.svelte",
+    );
+}
+
+/// Cached transformed output must contain exactly one `import type { PageProps }`.
+/// Two means the hoist+strip pair is broken (the bug from issue #144).
+#[test]
+fn test_issue_144_transformed_output_has_single_pageprops_import() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let _ = run_check_json(&fixture_path);
+
+    let relative_path = "src/routes/issue-144-duplicate-pageprops/+page.svelte.ts";
+    let content = find_transformed_cache_content(&fixture_path, relative_path)
+        .unwrap_or_else(|| panic!("missing transformed cache for issue-144 +page.svelte"));
+
+    let pageprops_import_count = content.matches("import type { PageProps }").count();
+    assert_eq!(
+        pageprops_import_count, 1,
+        "Issue #144: expected exactly 1 `import type {{ PageProps }}` in transformed output, found {}:\n{}",
+        pageprops_import_count, content
+    );
+}

--- a/crates/svelte-check-rs/tests/integration_issues.rs
+++ b/crates/svelte-check-rs/tests/integration_issues.rs
@@ -2036,3 +2036,62 @@ fn test_issue_144_transformed_output_has_single_pageprops_import() {
         pageprops_import_count, content
     );
 }
+// ============================================================================
+// ISSUE #146: MODULE-LEVEL `type X = unknown` STRIPPED WHEN `generics=` PRESENT
+// ============================================================================
+// When a component has both a `<script lang="ts" module>` containing
+// `type T = unknown` declarations *and* a `<script generics="T extends ...">`
+// instance block that re-uses the same identifiers, the transformer stripped
+// the module-level aliases. Any other code that referenced them (e.g.
+// `interface Column<T = TValue>`) then failed with TS2304.
+//
+// Fixture: src/lib/issue-146-module-generic-unknown.svelte
+//   Module script lines 2-3: type TData = unknown; type TValue = unknown;
+//   Line 5:  interface Column<T = TValue>         <- TValue must still exist
+//   Line 11: interface DataTableProps<TPropData = TData, TPropValue = TValue>
+#[test]
+fn test_issue_146_module_unknown_aliases_not_stripped() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let (_exit_code, diagnostics) = run_check_json(&fixture_path);
+    let ts_diagnostics = filter_diagnostics_by_source(&diagnostics, "ts");
+
+    let cannot_find: Vec<_> = ts_diagnostics
+        .iter()
+        .filter(|d| {
+            d.filename
+                .ends_with("issue-146-module-generic-unknown.svelte")
+                && d.code == "TS2304"
+                && (d.message.contains("TData") || d.message.contains("TValue"))
+        })
+        .collect();
+    assert!(
+        cannot_find.is_empty(),
+        "Issue #146: module-level `type X = unknown` aliases were stripped:\n{:#?}",
+        cannot_find
+    );
+
+    assert_no_diagnostics_in_file(&ts_diagnostics, "issue-146-module-generic-unknown.svelte");
+}
+
+/// Cached transformed output must still contain the module-level `type ... = unknown`
+/// declarations — they're load-bearing for the interfaces that reference them.
+#[test]
+fn test_issue_146_transformed_output_preserves_unknown_aliases() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let _ = run_check_json(&fixture_path);
+
+    let relative_path = "src/lib/issue-146-module-generic-unknown.svelte.ts";
+    let content = find_transformed_cache_content(&fixture_path, relative_path)
+        .unwrap_or_else(|| panic!("missing transformed cache for issue-146 component"));
+
+    assert!(
+        content.contains("type TData = unknown") || content.contains("type TData=unknown"),
+        "Issue #146: transformed output missing `type TData = unknown`:\n{}",
+        content
+    );
+    assert!(
+        content.contains("type TValue = unknown") || content.contains("type TValue=unknown"),
+        "Issue #146: transformed output missing `type TValue = unknown`:\n{}",
+        content
+    );
+}

--- a/crates/svelte-parser/src/parser.rs
+++ b/crates/svelte-parser/src/parser.rs
@@ -2549,7 +2549,10 @@ impl<'src> Parser<'src> {
         // that separates the expression from the pattern, since the expression itself
         // may contain TypeScript " as " casts.
         // Note: " as" may be followed by any whitespace (space, newline, tab).
-        let (expression, expression_span, rest, rest_offset) = {
+        // `item_less` marks the `{#each EXPR, INDEX}` form (no `as` binding),
+        // where `rest` holds only the index (plus an optional key) and there is
+        // no value binding. See `parse_each_rest` for how that changes parsing.
+        let (expression, expression_span, rest, rest_offset, item_less) = {
             // Find all occurrences of " as" followed by whitespace and use the last one
             let mut last_as_match: Option<(usize, usize)> = None;
             let mut search_start = 0;
@@ -2568,18 +2571,69 @@ impl<'src> Parser<'src> {
                     TextSize::from(u32::from(expr_start) + as_pos as u32),
                 );
                 let rest_start = as_pos + match_len;
-                (expr, expr_span, &full_expr[rest_start..], rest_start)
+                (expr, expr_span, &full_expr[rest_start..], rest_start, false)
+            } else if let Some(comma_pos) = Self::find_char_in_expr(&full_expr, ',') {
+                // `{#each EXPR, INDEX}` — each block without an item.
+                // <https://svelte.dev/docs/svelte/each#Each-blocks-without-an-item>
+                // Split on the top-level comma: left side is the iterable, the
+                // right side is the index (and possibly a `(key)`).
+                let expr = full_expr[..comma_pos].trim().to_string();
+                let expr_span = Span::new(
+                    expr_start,
+                    TextSize::from(u32::from(expr_start) + comma_pos as u32),
+                );
+                let rest_start = comma_pos + 1;
+                (expr, expr_span, &full_expr[rest_start..], rest_start, true)
             } else {
-                (full_expr.trim().to_string(), full_span, "", 0)
+                (full_expr.trim().to_string(), full_span, "", 0, false)
             }
         };
 
         let rest = rest.trim();
 
-        // Parse context and index using brace-aware parsing
-        let (context, context_span, index, key) = if let Some(paren_pos) =
-            Self::find_char_in_expr(rest, '(')
-        {
+        // Parse context and index using brace-aware parsing.
+        //
+        // For the item-less form `{#each EXPR, INDEX (key)?}`, `rest` is just
+        // `INDEX (key)?` with no value binding, so `context` stays empty and the
+        // whole pre-paren chunk is the index.
+        let (context, context_span, index, key) = if item_less {
+            let (idx_part, key) = if let Some(paren_pos) = Self::find_char_in_expr(rest, '(') {
+                let key_start = paren_pos + 1;
+                let key_end = rest.len().saturating_sub(1); // trailing )
+                let key_expr = if key_start < key_end {
+                    rest[key_start..key_end].trim().to_string()
+                } else {
+                    String::new()
+                };
+                let key_span_start = TextSize::from(
+                    u32::from(expr_start) + rest_offset as u32 + paren_pos as u32 + 1,
+                );
+                let key_span_end =
+                    TextSize::from(u32::from(expr_start) + rest_offset as u32 + key_end as u32);
+                (
+                    rest[..paren_pos].trim(),
+                    Some(EachKey {
+                        span: Span::new(key_span_start, key_span_end),
+                        expression: key_expr,
+                    }),
+                )
+            } else {
+                (rest, None)
+            };
+
+            let ctx_span_start = TextSize::from(u32::from(expr_start) + rest_offset as u32);
+            let index = if idx_part.is_empty() {
+                None
+            } else {
+                Some(SmolStr::new(idx_part))
+            };
+            (
+                String::new(),
+                Span::new(ctx_span_start, ctx_span_start),
+                index,
+                key,
+            )
+        } else if let Some(paren_pos) = Self::find_char_in_expr(rest, '(') {
             // Has key expression: item, index (key)
             let before_paren = rest[..paren_pos].trim();
 
@@ -3439,6 +3493,47 @@ mod tests {
             assert!(block.key.is_some());
             let key = block.key.as_ref().unwrap();
             assert_eq!(key.expression.trim(), "item.id");
+        } else {
+            panic!("Expected EachBlock");
+        }
+    }
+
+    #[test]
+    fn test_parse_each_without_item() {
+        // `{#each EXPR, INDEX}` — each block without an item (issue #143).
+        let result = Parser::new(
+            "{#each { length: 4 }, i}{i}{/each}",
+            ParseOptions::default(),
+        )
+        .parse();
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+        if let TemplateNode::EachBlock(block) = &result.document.fragment.nodes[0] {
+            assert_eq!(block.expression.trim(), "{ length: 4 }");
+            assert_eq!(block.context.trim(), "");
+            assert_eq!(block.index, Some(SmolStr::new("i")));
+            assert!(block.key.is_none());
+        } else {
+            panic!("Expected EachBlock");
+        }
+    }
+
+    #[test]
+    fn test_parse_each_without_item_with_key() {
+        // Item-less each blocks may still carry a `(key)`.
+        let result = Parser::new(
+            "{#each { length: 4 }, i (i)}{i}{/each}",
+            ParseOptions::default(),
+        )
+        .parse();
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+        if let TemplateNode::EachBlock(block) = &result.document.fragment.nodes[0] {
+            assert_eq!(block.expression.trim(), "{ length: 4 }");
+            assert_eq!(block.context.trim(), "");
+            assert_eq!(block.index, Some(SmolStr::new("i")));
+            let key = block.key.as_ref().expect("expected key");
+            assert_eq!(key.expression.trim(), "i");
         } else {
             panic!("Expected EachBlock");
         }

--- a/crates/svelte-transformer/src/runes.rs
+++ b/crates/svelte-transformer/src/runes.rs
@@ -1056,6 +1056,17 @@ impl<'a> RuneScanner<'a> {
                         self.push_str("({} as __SvelteLoosen<");
                         self.push_str(&type_str);
                         self.push_str(">)");
+                    } else if self.default_props_type.is_none()
+                        && self.lhs_destructure_binds_children()
+                    {
+                        // Untyped `let { children } = $props()` — type `children`
+                        // as an optional no-arg Snippet so `{@render children?.()}`
+                        // type-checks (issue #145). The `<[]>` matters: Svelte's
+                        // Snippet resolves its rest args to `never` for non-tuple
+                        // parameter lists, so the alias default (`any[]`) would
+                        // reject a zero-arg call. `__SvelteLoosen` keeps the
+                        // pattern open for any other destructured props.
+                        self.push_str("({} as __SvelteLoosen<{ children?: __SvelteSnippet<[]> }>)");
                     } else {
                         self.push_str("({} as __SvelteLoosen<");
                         self.push_str(fallback_type);
@@ -1315,6 +1326,169 @@ impl<'a> RuneScanner<'a> {
 
         Some(type_str.to_string())
     }
+
+    /// Returns true when the `$props()` LHS is an object-destructure (with no
+    /// type annotation) that binds `children`.
+    ///
+    /// Svelte's `children` prop is an optional `Snippet`. Without an annotation
+    /// our fallback props type is `Record<string, unknown>`, which makes
+    /// `children` `unknown` and breaks `{@render children?.()}` (TS2349). When
+    /// `children` is destructured we instead loosen `{ children?: Snippet }`
+    /// (issue #145). The output buffer at this point ends with the LHS, e.g.
+    /// `let { children } = `.
+    fn lhs_destructure_binds_children(&self) -> bool {
+        let output = &self.output;
+        let bytes = output.as_bytes();
+
+        // Find the `$props()` assignment `=` (mirrors `extract_type_from_lhs`).
+        let mut equals_pos = None;
+        for i in (0..bytes.len()).rev() {
+            if bytes[i] != b'=' {
+                continue;
+            }
+            let prev = if i > 0 { bytes[i - 1] } else { 0 };
+            let next = if i + 1 < bytes.len() { bytes[i + 1] } else { 0 };
+            if next == b'=' || next == b'>' {
+                continue;
+            }
+            if prev == b'=' || prev == b'!' || prev == b'<' || prev == b'>' {
+                continue;
+            }
+            equals_pos = Some(i);
+            break;
+        }
+        let Some(equals_pos) = equals_pos else {
+            return false;
+        };
+
+        // No type annotation: the LHS ends with the destructure `}`.
+        let before = output[..equals_pos].trim_end();
+        if !before.ends_with('}') {
+            return false;
+        }
+
+        // Walk forward to find the last top-level `{...}` group (the
+        // destructure), tracking string/template/comment context so braces in
+        // string defaults don't throw off the depth count.
+        let Some(pattern) = last_top_level_brace_group(before) else {
+            return false;
+        };
+        pattern_binds_children(&pattern)
+    }
+}
+
+/// Extracts the contents of the last top-level `{...}` group in `src`,
+/// skipping braces that appear inside strings, template literals, or comments.
+fn last_top_level_brace_group(src: &str) -> Option<String> {
+    let mask = build_comment_mask(src);
+    let chars: Vec<(usize, char)> = src.char_indices().collect();
+    let mut depth = 0i32;
+    let mut group_start: Option<usize> = None;
+    let mut in_string: Option<char> = None;
+    let mut last_group: Option<(usize, usize)> = None;
+    let mut i = 0;
+    while i < chars.len() {
+        let (idx, ch) = chars[i];
+        if mask.get(idx).copied().unwrap_or(false) {
+            i += 1;
+            continue;
+        }
+        if let Some(quote) = in_string {
+            if ch == quote && !is_escaped(&chars, i) {
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+        match ch {
+            '\'' | '"' | '`' => in_string = Some(ch),
+            '{' => {
+                if depth == 0 {
+                    group_start = Some(idx + ch.len_utf8());
+                }
+                depth += 1;
+            }
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    if let Some(start) = group_start.take() {
+                        last_group = Some((start, idx));
+                    }
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    last_group.map(|(start, end)| src[start..end].to_string())
+}
+
+fn is_escaped(chars: &[(usize, char)], i: usize) -> bool {
+    let mut backslashes = 0;
+    let mut j = i;
+    while j > 0 && chars[j - 1].1 == '\\' {
+        backslashes += 1;
+        j -= 1;
+    }
+    backslashes % 2 == 1
+}
+
+/// Returns true if an object-destructure pattern binds `children` at the top
+/// level (`{ children }`, `{ children = ... }`, `{ children: c }`, `{ a, children }`).
+fn pattern_binds_children(pattern: &str) -> bool {
+    split_top_level_commas(pattern).iter().any(|part| {
+        let part = part.trim();
+        // Strip a default (`children = ...`) and a rename target
+        // (`children: local`); the prop name is the leading identifier.
+        let key = part
+            .split(['=', ':'])
+            .next()
+            .unwrap_or("")
+            .trim()
+            .trim_start_matches("...");
+        key == "children"
+    })
+}
+
+/// Splits on commas that sit at brace/paren/bracket depth 0, ignoring commas
+/// inside nested groups or strings.
+fn split_top_level_commas(src: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut depth = 0i32;
+    let mut in_string: Option<char> = None;
+    let mut prev_escape = false;
+    for ch in src.chars() {
+        if let Some(quote) = in_string {
+            current.push(ch);
+            if prev_escape {
+                prev_escape = false;
+            } else if ch == '\\' {
+                prev_escape = true;
+            } else if ch == quote {
+                in_string = None;
+            }
+            continue;
+        }
+        match ch {
+            '\'' | '"' | '`' => {
+                in_string = Some(ch);
+                current.push(ch);
+            }
+            '{' | '(' | '[' => {
+                depth += 1;
+                current.push(ch);
+            }
+            '}' | ')' | ']' => {
+                depth -= 1;
+                current.push(ch);
+            }
+            ',' if depth == 0 => parts.push(std::mem::take(&mut current)),
+            _ => current.push(ch),
+        }
+    }
+    parts.push(current);
+    parts
 }
 
 fn build_comment_mask(source: &str) -> Vec<bool> {
@@ -1933,7 +2107,7 @@ function updateEndTime() {
         let result = transform_runes(
             r#"import 'virtual:something';
 
-let { children } = $props();"#,
+let { data } = $props();"#,
             0,
         );
         // The output should NOT contain the import string as part of the type
@@ -1955,24 +2129,56 @@ let { children } = $props();"#,
     #[test]
     fn test_props_with_colon_in_block_comment() {
         let result = transform_runes(
-            "let { children } = /* note: comment before props */ $props();",
+            "let { data } = /* note: comment before props */ $props();",
             0,
         );
         assert_eq!(
             result.output,
-            "let { children } = /* note: comment before props */ ({} as __SvelteLoosen<Record<string, unknown>>);"
+            "let { data } = /* note: comment before props */ ({} as __SvelteLoosen<Record<string, unknown>>);"
         );
     }
 
     #[test]
     fn test_props_with_trailing_inline_comment() {
         let result = transform_runes(
-            "let { children } = $props(); // trailing: comment after props",
+            "let { data } = $props(); // trailing: comment after props",
             0,
         );
         assert_eq!(
             result.output,
-            "let { children } = ({} as __SvelteLoosen<Record<string, unknown>>); // trailing: comment after props"
+            "let { data } = ({} as __SvelteLoosen<Record<string, unknown>>); // trailing: comment after props"
+        );
+    }
+
+    #[test]
+    fn test_props_untyped_children_is_snippet() {
+        // Issue #145: untyped `children` should be an optional no-arg Snippet,
+        // not `unknown`, so `{@render children?.()}` type-checks.
+        let result = transform_runes("let { children } = $props();", 0);
+        assert_eq!(
+            result.output,
+            "let { children } = ({} as __SvelteLoosen<{ children?: __SvelteSnippet<[]> }>);"
+        );
+    }
+
+    #[test]
+    fn test_props_untyped_children_among_other_props() {
+        // The Snippet fallback also applies when `children` is one of several
+        // destructured props; `__SvelteLoosen` keeps the rest open.
+        let result = transform_runes("let { foo, children, bar } = $props();", 0);
+        assert_eq!(
+            result.output,
+            "let { foo, children, bar } = ({} as __SvelteLoosen<{ children?: __SvelteSnippet<[]> }>);"
+        );
+    }
+
+    #[test]
+    fn test_props_annotated_children_unchanged() {
+        // An explicit annotation always wins over the `children` fallback.
+        let result = transform_runes("let { children }: { children: MySnippet } = $props();", 0);
+        assert_eq!(
+            result.output,
+            "let { children }: { children: MySnippet } = ({} as __SvelteLoosen<{ children: MySnippet }>);"
         );
     }
 

--- a/crates/svelte-transformer/src/template.rs
+++ b/crates/svelte-transformer/src/template.rs
@@ -1827,14 +1827,23 @@ impl TemplateContext {
         self.output.push_str(";\n");
 
         // Determine the loop variable pattern
-        let item_pattern = &block.context;
+        let item_pattern = block.context.trim();
         let index_var = block.index.as_ref().map(|i| i.to_string());
 
         if let Some(ref idx) = index_var {
-            self.emit(&format!(
-                "for (const [{}, {}] of __svelte_each_indexed(__each_{})) {{",
-                idx, item_pattern, id
-            ));
+            if item_pattern.is_empty() {
+                // Item-less form `{#each EXPR, INDEX}` — bind only the index.
+                // Array destructuring lets us drop the (unused) value element.
+                self.emit(&format!(
+                    "for (const [{}] of __svelte_each_indexed(__each_{})) {{",
+                    idx, id
+                ));
+            } else {
+                self.emit(&format!(
+                    "for (const [{}, {}] of __svelte_each_indexed(__each_{})) {{",
+                    idx, item_pattern, id
+                ));
+            }
         } else {
             self.emit(&format!("for (const {} of __each_{}) {{", item_pattern, id));
         }

--- a/crates/svelte-transformer/src/transform.rs
+++ b/crates/svelte-transformer/src/transform.rs
@@ -18,7 +18,7 @@ use svelte_parser::{
     TemplateNode,
 };
 use swc_common::{FileName, SourceMap as SwcSourceMap, Spanned};
-use swc_ecma_ast::{Module, ModuleDecl, ModuleItem, Stmt};
+use swc_ecma_ast::{ImportSpecifier, Module, ModuleDecl, ModuleItem, Stmt};
 use swc_ecma_parser::{Parser, StringInput, Syntax, TsSyntax};
 
 /// The kind of SvelteKit route file.
@@ -783,6 +783,31 @@ fn parse_script_module(script: &str) -> Option<Module> {
     parser.parse_module().ok()
 }
 
+/// Returns true if `script` has a top-level import that binds `name`
+/// (named, default, or namespace specifier).
+///
+/// Used to avoid injecting a synthetic SvelteKit `./$types` import when the
+/// user already imports that identifier themselves — emitting both produces
+/// a `TS2300 Duplicate identifier` (issue #144).
+fn script_imports_identifier(script: &str, name: &str) -> bool {
+    let Some(module) = parse_script_module(script) else {
+        return false;
+    };
+    module.body.iter().any(|item| {
+        let ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)) = item else {
+            return false;
+        };
+        import_decl.specifiers.iter().any(|spec| {
+            let local = match spec {
+                ImportSpecifier::Named(named) => &named.local.sym,
+                ImportSpecifier::Default(default) => &default.local.sym,
+                ImportSpecifier::Namespace(ns) => &ns.local.sym,
+            };
+            local.as_ref() == name
+        })
+    })
+}
+
 fn mask_range(bytes: &mut [u8], start: usize, end: usize) {
     if start >= end || start >= bytes.len() {
         return;
@@ -1158,7 +1183,21 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 
     // Add SvelteKit type imports for route files
     // Use .js extension for NodeNext/Node16 module resolution
-    if let Some(props_type) = route_kind.props_type() {
+    //
+    // Skip the synthetic import when the user already imports the same
+    // identifier (typically `import type { PageProps } from './$types'`);
+    // their import is hoisted separately, so injecting ours too would yield
+    // `TS2300 Duplicate identifier` (issue #144).
+    let user_imports_props_type = route_kind.props_type().is_some_and(|props_type| {
+        doc.instance_script
+            .as_ref()
+            .is_some_and(|s| script_imports_identifier(&s.content, props_type))
+            || doc
+                .module_script
+                .as_ref()
+                .is_some_and(|s| script_imports_identifier(&s.content, props_type))
+    });
+    if let Some(props_type) = route_kind.props_type().filter(|_| !user_imports_props_type) {
         let types_path = if options.use_nodenext_imports {
             "./$types.js"
         } else {

--- a/crates/svelte-transformer/src/transform.rs
+++ b/crates/svelte-transformer/src/transform.rs
@@ -1398,23 +1398,14 @@ declare module "svelte" {
         let base_offset: u32 = module.content_span.start.into();
         let rune_result =
             transform_runes_with_options(&module.content, base_offset, default_props_type);
-        let mut script_output = rune_result.output;
-        let mut script_mappings = rune_result.mappings;
-        let mut edits = Vec::new();
-        if !placeholder_types.is_empty() {
-            edits.extend(placeholder_type_alias_edits(
-                &script_output,
-                &placeholder_types,
-            ));
-        }
-        if !edits.is_empty() {
-            (script_output, script_mappings) = apply_script_edits_with_mappings(
-                &script_output,
-                base_offset,
-                &script_mappings,
-                edits,
-            );
-        }
+        // Module-script `type X = unknown` placeholder aliases are kept on
+        // purpose. Module-scope declarations (interfaces, other aliases) may use
+        // them as default type arguments, e.g. `interface Column<T = TValue>`;
+        // stripping them produces `TS2304 Cannot find name` (issue #146). They
+        // are stripped from the *instance* script below, where they would
+        // otherwise clash with the render function's generic parameters.
+        let script_output = rune_result.output;
+        let script_mappings = rune_result.mappings;
 
         let indent = script_indent(&script_output);
         if rune_result.uses_props_accessor {

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_comment_before.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_comment_before.snap
@@ -165,7 +165,7 @@ async function __svelte_render() {
     // See: issue-28 - comment before props
     const flag = true;
 
-    let { children } = ({} as __SvelteLoosen<Record<string, unknown>>);
+    let { children } = ({} as __SvelteLoosen<{ children?: __SvelteSnippet<[]> }>);
 
 
 // === TEMPLATE TYPE-CHECK ===

--- a/test-fixtures/projects/sveltekit-bundler/src/lib/issue-145-untyped-children.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/lib/issue-145-untyped-children.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  let { children } = $props();
+</script>
+
+<div class="wrapper">
+  {@render children?.()}
+</div>

--- a/test-fixtures/projects/sveltekit-bundler/src/lib/issue-146-module-generic-unknown.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/lib/issue-146-module-generic-unknown.svelte
@@ -1,0 +1,30 @@
+<script lang="ts" module>
+  type TData = unknown;
+  type TValue = unknown;
+
+  export interface Column<T = TValue> {
+    key: string;
+    label: string;
+    format?: (value: T) => string;
+  }
+
+  export interface DataTableProps<TPropData = TData, TPropValue = TValue> {
+    columns: Column<TPropValue>[];
+    data: TPropData[];
+  }
+</script>
+
+<script generics="TData extends unknown, TValue extends unknown" lang="ts">
+  let { columns, data }: DataTableProps<TData, TValue> = $props();
+</script>
+
+<table>
+  <thead>
+    <tr>{#each columns as col}<th>{col.label}</th>{/each}</tr>
+  </thead>
+  <tbody>
+    {#each data as row}
+      <tr>{#each columns as col}<td>{String(row)}</td>{/each}</tr>
+    {/each}
+  </tbody>
+</table>

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-143-each-no-item/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-143-each-no-item/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  let count = $state(4);
+</script>
+
+<button onclick={() => count++}>add</button>
+
+{#each { length: count }, i}
+  <div>placeholder {i}</div>
+{/each}
+
+{#each { length: 3 }, j}
+  <span>{j}</span>
+{/each}

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-144-duplicate-pageprops/+page.server.ts
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-144-duplicate-pageprops/+page.server.ts
@@ -1,0 +1,3 @@
+export function load() {
+  return { message: "hello" };
+}

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/issue-144-duplicate-pageprops/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/issue-144-duplicate-pageprops/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import type { PageProps } from "./$types";
+  let { data }: PageProps = $props();
+</script>
+
+<p>{data.message}</p>


### PR DESCRIPTION
## Summary

Fixes four reproducible bugs reported via minimal repros (#143–#146), each as its own commit. Issue **#147** was investigated and found to be a **false positive** (upstream `svelte-check` reports the same error) — see [the issue comment](https://github.com/pheuter/svelte-check-rs/issues/147) — so it is intentionally not addressed here.

Each fix lands together with its `.svelte` fixture in `sveltekit-bundler` and an integration test in `integration_issues.rs` that fails before the fix and passes after.

## Fixes

**fix(parser): support each blocks without an item (#143)**
Svelte's [`{#each EXPR, INDEX}`](https://svelte.dev/docs/svelte/each#Each-blocks-without-an-item) form had no `as` branch, so the whole `EXPR, INDEX` chunk landed in the iterable and the transformer emitted invalid TS (`const __each_0 = { length: 4 }, i;` + `for (const  of …)`), tripping TS1155/TS7005/TS1123. The parser now splits on the top-level comma when no `as` is present (right side = index, optional `(key)`); the transformer emits `for (const [i] of __svelte_each_indexed(…))`.

**fix(transformer): avoid duplicate \$types import for routes (#144)**
Route files inject a synthetic `import type { PageProps } from './\$types'`. When the user already wrote that import, both were emitted → `TS2300 Duplicate identifier`. The synthetic import is now skipped when the user's script already binds the identifier.

**fix(transformer): keep module-script unknown placeholder aliases (#146)**
Module-scope `type T = unknown` placeholders (used so module-level interfaces can reference `generics=` params by name) were stripped, breaking references like `interface Column<T = TValue>` with `TS2304`. Placeholder detection still drives which generics to keep, but the alias lines are now stripped only from the instance script (where they would clash with the render fn's generic params), not the module script.

**fix(transformer): infer untyped children as Snippet (#145)**
`let { children } = \$props()` widened to `Record<string, unknown>`, so `children` was `unknown` and `{@render children?.()}` failed with `TS2349`. Untyped `children` now falls back to `__SvelteLoosen<{ children?: __SvelteSnippet<[]> }>`. The `<[]>` is required: Svelte's `Snippet` resolves its rest args to `never` for non-tuple parameter lists, so the alias default (`any[]`) would reject a zero-arg render call. An explicit annotation still wins.

## Testing

- `cargo test --workspace` — all green (151 transformer unit tests, 57 `integration_issues`, 45 `integration_tsconfig`, snapshots, corpus)
- `cargo clippy --all-targets -- -D warnings` — clean
- Built binary run against all four original repro repos — **0 errors** in each affected file
- `integration_tsconfig.rs` unchanged vs `main` (bundler error count stays 21): each fixture lands already-fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)