### PR TITLE
ci(npm): make npm publish loop idempotent

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -65,4 +65,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          node -e "const fs=require('fs');const {execSync}=require('child_process');const tag='${{ steps.resolve-tag.outputs.tag }}';const distTag=tag.includes('-')?'beta':'latest';const data=JSON.parse(fs.readFileSync('dist/npm/publish-order.json','utf8'));for(const pkg of data.packages){console.log('Publishing',pkg,'tag',distTag);execSync('npm publish --access public --tag '+distTag+' \"'+pkg+'\"',{stdio:'inherit'});}"
+          node scripts/npm/publish-packages.mjs \
+            --tag "${{ steps.resolve-tag.outputs.tag }}" \
+            --out-dir dist/npm

--- a/scripts/npm/publish-packages.mjs
+++ b/scripts/npm/publish-packages.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function parseArgs(argv) {
+  const args = { tag: null, outDir: null };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--tag") {
+      args.tag = argv[++i];
+    } else if (arg === "--out-dir") {
+      args.outDir = argv[++i];
+    }
+  }
+  return args;
+}
+
+function fail(message) {
+  console.error(`[publish-packages] ${message}`);
+  process.exit(1);
+}
+
+// npm returns a 403 with this message when the exact version already exists on
+// the registry. This also surfaces after a transient retry where the first PUT
+// actually succeeded but the client retried and saw the version now present.
+// Treat it as success so a re-run (or a partially-published release) is
+// idempotent and never strands later packages in publish-order.json.
+function isAlreadyPublished(output) {
+  return (
+    /cannot publish over the previously published versions?/i.test(output) ||
+    /EPUBLISHCONFLICT/.test(output)
+  );
+}
+
+const { tag, outDir } = parseArgs(process.argv);
+if (!tag || !outDir) {
+  fail("Usage: node scripts/npm/publish-packages.mjs --tag <tag> --out-dir <dir>");
+}
+
+const distTag = tag.includes("-") ? "beta" : "latest";
+const orderPath = path.join(outDir, "publish-order.json");
+const { packages } = JSON.parse(fs.readFileSync(orderPath, "utf8"));
+
+const skipped = [];
+const failures = [];
+
+for (const pkg of packages) {
+  console.log(`Publishing ${pkg} (tag ${distTag})`);
+  const result = spawnSync(
+    "npm",
+    ["publish", "--access", "public", "--tag", distTag, pkg],
+    { encoding: "utf8" }
+  );
+
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+
+  if (result.status === 0) continue;
+
+  const output = `${result.stdout || ""}\n${result.stderr || ""}`;
+  if (isAlreadyPublished(output)) {
+    console.log(`  -> already published, skipping ${pkg}`);
+    skipped.push(pkg);
+    continue;
+  }
+
+  failures.push(pkg);
+}
+
+console.log(
+  `\nPublish summary: ${packages.length - skipped.length - failures.length} published, ` +
+    `${skipped.length} already present, ${failures.length} failed`
+);
+
+if (failures.length > 0) {
+  fail(`Failed to publish: ${failures.join(", ")}`);
+}


### PR DESCRIPTION
## Summary

The `NPM Release` workflow's publish step looped over `publish-order.json` running `npm publish` for each package with **no error handling**. A single failed publish aborted the entire loop.

## Why

In [run 26819356080](https://github.com/pheuter/svelte-check-rs/actions/runs/26819356080) (v0.9.20), npm's client returned a false `E403` — *"You cannot publish over the previously published versions: 0.9.20"* — on `@svelte-check-rs/win32-x64`. The timestamps show the package had **actually been published** seconds earlier (`12:22:22Z`); the 403 came from an internal client retry that saw the version now present. That fatal error crashed the loop.

Because `publish-order.json` is ordered `[...platform packages, main package]`, the crash left the release **half-published**:

| package | version |
|---|---|
| all 5 `@svelte-check-rs/*` platform packages | `0.9.20` ✅ |
| `svelte-check-rs` (main) | `0.9.19` ❌ never reached |

So `npm install svelte-check-rs` still resolved to 0.9.19. A plain re-run couldn't fix it either — it would hit `E403` on the *first* already-published platform package and die again.

## Details

Replaces the brittle inline `node -e` one-liner with `scripts/npm/publish-packages.mjs`, which:

- Treats "already published" (`E403` conflict / `EPUBLISHCONFLICT`) as success and continues to the next package.
- Still fails the job on any genuine error (auth, network, etc.).
- Prints a publish summary (published / already-present / failed).

This makes the publish step **idempotent**: a transient npm hiccup can no longer strand later packages, and re-running a partially-published release is safe.

## Testing

- `node --check` passes; conflict-detection regex verified against the real E403 message text, `EPUBLISHCONFLICT`, and a generic error (to confirm it does *not* over-match).
- Follow-up: re-dispatch `NPM Release` for `v0.9.20` to publish the missing main package (will skip the 5 existing platform packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)