### PR TITLE
fix(transformer): wrap bind expressions used as statements

### DIFF
--- a/crates/svelte-transformer/src/template.rs
+++ b/crates/svelte-transformer/src/template.rs
@@ -1516,8 +1516,22 @@ impl TemplateContext {
                     self.output.push_str(&setter);
                     self.output.push_str("];\n");
                 } else {
-                    // For bindings, check the variable
-                    self.emit_expression(&expr.expression, expr.expression_span, context);
+                    // For bindings, check the expression as an expression, not
+                    // as a bare statement. Type assertions such as
+                    // `bind:value={value as never}` are valid expressions but
+                    // invalid expression statements in TypeScript.
+                    let transformed = self.transform_expr(&expr.expression);
+                    self.expressions.push(TemplateExpression {
+                        expression: transformed.clone(),
+                        span: expr.expression_span,
+                        context,
+                    });
+                    let indent_str = self.indent_str();
+                    self.output.push_str(&indent_str);
+                    self.output.push_str("void (");
+                    self.record_mapping_at_current_pos(&transformed, expr.expression_span);
+                    self.output.push_str(&transformed);
+                    self.output.push_str(");\n");
                 }
             } else {
                 // For style directives and other directives, emit the expression

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bind_value_component_expression.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bind_value_component_expression.snap
@@ -176,7 +176,7 @@ async function __svelte_render() {
   { const __component_0 = __svelte_ensure_component(Combobox); __component_0(__svelte_any(), {
     value: value as string | null,
   }); }
-  value as string | null;
+  void (value as string | null);
 return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, events: {} };
 }
 


### PR DESCRIPTION
## Summary

Wrap non-`bind:this` binding expression checks in `void (...)`.

## Why

A binding expression can be a valid expression but not a valid TypeScript expression statement, for example a type assertion:

```svelte
<Component bind:value={value as never} />
```

Emitting it as a bare statement produces invalid TypeScript. Wrapping it as `void (...)` keeps the expression type-checked while preserving valid generated code.

## Testing

- `cargo test -p svelte-transformer test_bind_value_component_emits_expression_for_type_checking --test snapshots`
- `cargo build -p svelte-check-rs`