### PR TITLE
fix(cli): generate declaration stubs for external workspace Svelte files

### DIFF
--- a/crates/svelte-check-rs/src/orchestrator.rs
+++ b/crates/svelte-check-rs/src/orchestrator.rs
@@ -8,7 +8,7 @@ use bun_runner::{
     BunRunner,
 };
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
-use globset::{Glob, GlobSetBuilder};
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use rayon::prelude::*;
 use source_map::LineIndex;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -256,6 +256,148 @@ fn is_ignored_dir(ignore_set: &globset::GlobSet, relative: &Utf8Path) -> bool {
     ignore_set.is_match(&rel_slash)
 }
 
+fn path_starts_with(path: &Utf8Path, base: &Utf8Path) -> bool {
+    let path = to_forward_slash(path).to_ascii_lowercase();
+    let base = to_forward_slash(base).to_ascii_lowercase();
+    path == base || path.starts_with(&format!("{base}/"))
+}
+
+fn package_json_has_workspaces(path: &Utf8Path) -> bool {
+    let Ok(content) = fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+    json.get("workspaces").is_some()
+}
+
+fn find_package_workspace_root(workspace: &Utf8Path) -> Option<Utf8PathBuf> {
+    let mut current = Some(workspace);
+    while let Some(dir) = current {
+        if package_json_has_workspaces(&dir.join("package.json")) {
+            return Some(dir.to_owned());
+        }
+        current = dir.parent();
+    }
+    None
+}
+
+fn virtual_base_for<'a>(
+    file_path: &Utf8Path,
+    workspace: &'a Utf8Path,
+    monorepo_root: Option<&'a Utf8Path>,
+) -> &'a Utf8Path {
+    if path_starts_with(file_path, workspace) {
+        workspace
+    } else {
+        monorepo_root.unwrap_or(workspace)
+    }
+}
+
+fn external_declaration_content(scripts: &[&str]) -> String {
+    let mut out = String::new();
+    for script in scripts {
+        for line in script.lines() {
+            let trimmed = line.trim_start();
+            if let Some(name) = exported_name_after(trimmed, "export type ") {
+                out.push_str(&format!("export type {name} = any;\n"));
+            } else if let Some(name) = exported_name_after(trimmed, "export interface ") {
+                out.push_str(&format!("export type {name} = any;\n"));
+            } else if let Some(name) = exported_name_after(trimmed, "export function ") {
+                out.push_str(&format!("export declare const {name}: any;\n"));
+            } else if let Some(name) = exported_name_after(trimmed, "export const ") {
+                out.push_str(&format!("export declare const {name}: any;\n"));
+            } else if let Some(name) = exported_name_after(trimmed, "export let ") {
+                out.push_str(&format!("export declare const {name}: any;\n"));
+            } else if let Some(name) = exported_name_after(trimmed, "export var ") {
+                out.push_str(&format!("export declare const {name}: any;\n"));
+            } else if let Some(name) = exported_name_after(trimmed, "export class ") {
+                out.push_str(&format!("export declare const {name}: any;\n"));
+            } else if let Some(names) = exported_names_in_braces(trimmed, "export type {") {
+                for name in names {
+                    out.push_str(&format!("export type {name} = any;\n"));
+                }
+            } else if let Some(names) = exported_names_in_braces(trimmed, "export {") {
+                for name in names {
+                    out.push_str(&format!("export declare const {name}: any;\n"));
+                }
+            }
+        }
+    }
+    out.push_str("declare const _default: any;\nexport default _default;\n");
+    out
+}
+
+fn exported_names_in_braces(line: &str, prefix: &str) -> Option<Vec<String>> {
+    let rest = line.strip_prefix(prefix)?;
+    let body = rest.split('}').next()?;
+    let names: Vec<String> = body
+        .split(',')
+        .filter_map(|part| {
+            let part = part.trim().strip_prefix("type ").unwrap_or(part.trim());
+            let name = part
+                .rsplit_once(" as ")
+                .map(|(_, exported)| exported)
+                .unwrap_or(part);
+            let name: String = name
+                .trim()
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '$')
+                .collect();
+            (!name.is_empty()).then_some(name)
+        })
+        .collect();
+    (!names.is_empty()).then_some(names)
+}
+
+fn exported_name_after(line: &str, prefix: &str) -> Option<String> {
+    let rest = line.strip_prefix(prefix)?.trim_start();
+    let name: String = rest
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '$')
+        .collect();
+    (!name.is_empty()).then_some(name)
+}
+
+fn discover_svelte_files(
+    scan_root: &Utf8Path,
+    ignore_root: &Utf8Path,
+    ignore_set: &GlobSet,
+    extensions: &[&str],
+    seen_files: &mut HashSet<Utf8PathBuf>,
+) -> Vec<Utf8PathBuf> {
+    WalkDir::new(scan_root)
+        .into_iter()
+        .filter_entry(|entry| {
+            if entry.depth() == 0 {
+                return true;
+            }
+            if !entry.file_type().is_dir() {
+                return true;
+            }
+            let path = match Utf8Path::from_path(entry.path()) {
+                Some(path) => path,
+                None => return true,
+            };
+            let relative = path.strip_prefix(ignore_root).unwrap_or(path);
+            !is_ignored_dir(ignore_set, relative)
+        })
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .filter_map(|e| Utf8PathBuf::try_from(e.into_path()).ok())
+        .filter(|p| {
+            let file_name = p.file_name().unwrap_or("");
+            extensions.iter().any(|ext| file_name.ends_with(ext))
+        })
+        .filter(|p| {
+            let relative = p.strip_prefix(ignore_root).unwrap_or(p);
+            !ignore_set.is_match(to_forward_slash(relative).as_str())
+        })
+        .filter(|p| seen_files.insert(p.clone()))
+        .collect()
+}
+
 /// Orchestration errors.
 #[derive(Debug, Error)]
 pub enum OrchestratorError {
@@ -461,37 +603,30 @@ pub async fn run(args: Args) -> Result<CheckSummary, OrchestratorError> {
         .build()
         .map_err(|e| OrchestratorError::InvalidGlob(e.to_string()))?;
 
-    // Find Svelte files
+    // Find Svelte files. When checking a package inside a package-manager
+    // workspace, also discover sibling workspace package Svelte files so
+    // TypeScript imports can resolve their declaration stubs.
     let scan_start = Instant::now();
     let extensions = svelte_config.file_extensions();
-    let files: Vec<Utf8PathBuf> = WalkDir::new(&workspace)
-        .into_iter()
-        .filter_entry(|entry| {
-            if entry.depth() == 0 {
-                return true;
-            }
-            if !entry.file_type().is_dir() {
-                return true;
-            }
-            let path = match Utf8Path::from_path(entry.path()) {
-                Some(path) => path,
-                None => return true,
-            };
-            let relative = path.strip_prefix(&workspace).unwrap_or(path);
-            !is_ignored_dir(&ignore_set, relative)
-        })
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().is_file())
-        .filter_map(|e| Utf8PathBuf::try_from(e.into_path()).ok())
-        .filter(|p| {
-            let file_name = p.file_name().unwrap_or("");
-            extensions.iter().any(|ext| file_name.ends_with(ext))
-        })
-        .filter(|p| {
-            let relative = p.strip_prefix(&workspace).unwrap_or(p);
-            !ignore_set.is_match(to_forward_slash(relative).as_str())
-        })
-        .collect();
+    let mut seen_files = HashSet::new();
+    let mut files = discover_svelte_files(
+        &workspace,
+        &workspace,
+        &ignore_set,
+        &extensions,
+        &mut seen_files,
+    );
+    if let Some(monorepo_root) = find_package_workspace_root(&workspace) {
+        if monorepo_root != workspace {
+            files.extend(discover_svelte_files(
+                &monorepo_root,
+                &monorepo_root,
+                &ignore_set,
+                &extensions,
+                &mut seen_files,
+            ));
+        }
+    }
     let file_scan_time = if timings_enabled {
         Some(scan_start.elapsed())
     } else {
@@ -612,10 +747,25 @@ async fn run_single_check(
     }
 
     // Separate files by kind: components (.svelte) vs modules (.svelte.ts/.svelte.js)
-    let (component_files, module_files): (Vec<_>, Vec<_>) = files
+    let (component_files, mut module_files): (Vec<_>, Vec<_>) = files
         .into_iter()
         .partition(|f| SvelteFileKind::from_path(f) == Some(SvelteFileKind::Component));
+    let component_file_set: HashSet<Utf8PathBuf> = component_files.iter().cloned().collect();
+    module_files.retain(|path| {
+        if path_starts_with(path, workspace) {
+            return true;
+        }
+        let path_str = path.as_str();
+        if let Some(component_path) = path_str.strip_suffix(".ts") {
+            return !component_file_set.contains(Utf8Path::new(component_path));
+        }
+        if let Some(component_path) = path_str.strip_suffix(".js") {
+            return !component_file_set.contains(Utf8Path::new(component_path));
+        }
+        true
+    });
 
+    let monorepo_root = find_package_workspace_root(workspace);
     let svelte_start = Instant::now();
 
     // Resolve the cache root once so each transform can compute the eventual
@@ -686,7 +836,8 @@ async fn run_single_check(
             let mut transformed = None;
             let should_transform = !args.skip_tsgo || args.emit_ts || args.emit_source_map;
             if should_transform {
-                let virtual_path = virtual_path_for(file_path, workspace, true);
+                let virtual_base = virtual_base_for(file_path, workspace, monorepo_root.as_deref());
+                let virtual_path = virtual_path_for(file_path, virtual_base, true);
                 let helpers_import = helpers_import_path_for(&virtual_path, use_nodenext_imports);
                 // Absolute path the transformed file will eventually be written
                 // to in the cache (matches `cache_root.join(virtual_path)` in
@@ -739,13 +890,27 @@ async fn run_single_check(
                 // Only add to transformed files collection if we're going to run tsgo
                 if !args.skip_tsgo {
                     // Create the virtual path (original.svelte -> original.svelte.ts)
-                    let virtual_path = virtual_path_for(file_path, workspace, true);
+                    let virtual_base =
+                        virtual_base_for(file_path, workspace, monorepo_root.as_deref());
+                    let virtual_path = virtual_path_for(file_path, virtual_base, true);
 
                     let tsx_code = transform_result.tsx_code;
+                    let is_external = !path_starts_with(file_path, workspace);
+                    let declaration_content = is_external.then(|| {
+                        let mut scripts = Vec::new();
+                        if let Some(script) = &parse_result.document.module_script {
+                            scripts.push(script.content.as_str());
+                        }
+                        if let Some(script) = &parse_result.document.instance_script {
+                            scripts.push(script.content.as_str());
+                        }
+                        external_declaration_content(&scripts)
+                    });
                     let transformed_file = TransformedFile {
                         original_path: file_path.clone(),
                         generated_line_index: LineIndex::new(&tsx_code),
                         tsx_content: tsx_code,
+                        declaration_content,
                         source_map: transform_result.source_map,
                         original_line_index: LineIndex::new(&source),
                     };
@@ -785,7 +950,10 @@ async fn run_single_check(
                 })
             };
 
-            let compiler_input = Some(BunInput {
+            // External workspace package files only provide declarations for
+            // imports. Keep compiler diagnostics scoped to the requested
+            // workspace.
+            let compiler_input = path_starts_with(file_path, workspace).then(|| BunInput {
                 filename: file_path.clone(),
                 source: source.clone(),
                 options: compiler_bun_options.clone(),
@@ -818,7 +986,8 @@ async fn run_single_check(
             };
 
             // Transform module file (runes only, no template/styles)
-            let virtual_path = virtual_path_for(file_path, workspace, false);
+            let virtual_base = virtual_base_for(file_path, workspace, monorepo_root.as_deref());
+            let virtual_path = virtual_path_for(file_path, virtual_base, false);
             let helpers_import = helpers_import_path_for(&virtual_path, use_nodenext_imports);
             // (workspace_path, generated_path) for out-of-root import rewriting.
             let external_imports = cache_root.as_ref().map(|root| {
@@ -862,13 +1031,18 @@ async fn run_single_check(
 
                 // For module files, we keep the same relative path (they're already .ts/.js)
                 // But we need to write transformed content to the cache
-                let virtual_path = virtual_path_for(file_path, workspace, false);
+                let virtual_base = virtual_base_for(file_path, workspace, monorepo_root.as_deref());
+                let virtual_path = virtual_path_for(file_path, virtual_base, false);
 
                 let tsx_code = transform_result.code;
+                let is_external = !path_starts_with(file_path, workspace);
+                let declaration_content =
+                    is_external.then(|| external_declaration_content(&[source.as_str()]));
                 let transformed_file = TransformedFile {
                     original_path: file_path.clone(),
                     generated_line_index: LineIndex::new(&tsx_code),
                     tsx_content: tsx_code,
+                    declaration_content,
                     source_map: transform_result.source_map,
                     original_line_index: LineIndex::new(&source),
                 };

--- a/crates/svelte-check-rs/tests/integration_workspace_stubs.rs
+++ b/crates/svelte-check-rs/tests/integration_workspace_stubs.rs
@@ -1,0 +1,122 @@
+//! Integration tests for package-manager workspace Svelte imports.
+
+use bun_runner::BunRunner;
+use camino::{Utf8Path, Utf8PathBuf};
+use serde::Deserialize;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn fixture_root() -> PathBuf {
+    workspace_root()
+        .join("test-fixtures")
+        .join("projects")
+        .join("workspace-stubs")
+}
+
+fn app_root() -> PathBuf {
+    fixture_root().join("app")
+}
+
+fn binary_path() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_svelte-check-rs") {
+        return PathBuf::from(path);
+    }
+    workspace_root()
+        .join("target")
+        .join("debug")
+        .join("svelte-check-rs")
+}
+
+static BIN_READY: OnceLock<()> = OnceLock::new();
+static FIXTURE_READY: OnceLock<()> = OnceLock::new();
+static BUN_PATH: OnceLock<Utf8PathBuf> = OnceLock::new();
+
+fn ensure_binary_built() {
+    BIN_READY.get_or_init(|| {
+        let output = Command::new("cargo")
+            .args(["build", "-p", "svelte-check-rs"])
+            .output()
+            .expect("cargo build");
+        assert!(output.status.success(), "cargo build failed");
+    });
+}
+
+fn bun_path_for(workspace: &Utf8Path) -> Utf8PathBuf {
+    BUN_PATH
+        .get_or_init(|| {
+            let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
+            runtime
+                .block_on(BunRunner::ensure_bun(Some(workspace)))
+                .expect("ensure bun")
+        })
+        .clone()
+}
+
+fn ensure_fixture_ready() {
+    FIXTURE_READY.get_or_init(|| {
+        let root = fixture_root();
+        let tsgo = root.join("node_modules").join(".bin").join("tsgo");
+        if !tsgo.exists() {
+            let root_utf8 = Utf8PathBuf::from_path_buf(root.clone()).expect("utf-8 fixture root");
+            let bun = bun_path_for(&root_utf8);
+            let output = Command::new(bun.as_std_path())
+                .arg("install")
+                .current_dir(&root)
+                .output()
+                .expect("bun install");
+            assert!(
+                output.status.success(),
+                "bun install failed:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    });
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct JsonDiagnostic {
+    filename: String,
+    code: String,
+    message: String,
+}
+
+#[test]
+fn workspace_package_svelte_imports_resolve_via_declaration_stubs() {
+    ensure_binary_built();
+    ensure_fixture_ready();
+
+    let output = Command::new(binary_path())
+        .arg("--workspace")
+        .arg(app_root())
+        .arg("--tsconfig")
+        .arg(app_root().join("tsconfig.json"))
+        .arg("--output")
+        .arg("json")
+        .output()
+        .expect("run svelte-check-rs");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let diagnostics: Vec<JsonDiagnostic> = serde_json::from_str(&stdout)
+        .unwrap_or_else(|err| panic!("failed to parse JSON output: {err}\nstdout:\n{stdout}"));
+
+    assert!(
+        output.status.success(),
+        "expected clean check, got diagnostics:\n{diagnostics:#?}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "unexpected diagnostics: {diagnostics:#?}"
+    );
+}

--- a/crates/tsgo-runner/src/runner.rs
+++ b/crates/tsgo-runner/src/runner.rs
@@ -358,6 +358,7 @@ struct TsconfigOverlayOptions<'a> {
     kit_include: Option<&'a Utf8Path>,
     patched_sources: &'a [Utf8PathBuf],
     extra_files: &'a [Utf8PathBuf],
+    extra_root_dir: Option<Utf8PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -978,8 +979,11 @@ impl TsgoRunner {
         root_dirs.retain(|dir| dir != &project_root && dir != &temp_root);
         let mut ordered_root_dirs = Vec::new();
         // Prefer cached files over project sources when both exist.
-        ordered_root_dirs.push(temp_root);
+        ordered_root_dirs.push(temp_root.clone());
         ordered_root_dirs.push(project_root);
+        if let Some(extra_root_dir) = &options.extra_root_dir {
+            ordered_root_dirs.push(to_forward_slash(extra_root_dir));
+        }
         ordered_root_dirs.extend(root_dirs);
         root_dirs = ordered_root_dirs;
         if let Some(kit_path) = options.kit_include {
@@ -1036,6 +1040,15 @@ impl TsgoRunner {
                             to_forward_slash(&clean_path(&options.temp_root.join(relative)));
                         if seen.insert(cached.clone()) {
                             resolved_values.push(Value::String(cached));
+                        }
+                    } else if let Some(extra_root_dir) = &options.extra_root_dir {
+                        if let Ok(relative) = Utf8Path::new(&resolved).strip_prefix(extra_root_dir)
+                        {
+                            let cached =
+                                to_forward_slash(&clean_path(&options.temp_root.join(relative)));
+                            if seen.insert(cached.clone()) {
+                                resolved_values.push(Value::String(cached));
+                            }
                         }
                     }
                     if seen.insert(resolved.clone()) {
@@ -1383,21 +1396,25 @@ impl TsgoRunner {
                     }
                 }
             }
-            let wrote = write_if_changed(&full_path, file.tsx_content.as_bytes(), "write tsx")?;
-            if wrote {
-                stats.cache.tsx_written += 1;
-            } else {
-                stats.cache.tsx_skipped += 1;
+            if file.declaration_content.is_none() {
+                let wrote = write_if_changed(&full_path, file.tsx_content.as_bytes(), "write tsx")?;
+                if wrote {
+                    stats.cache.tsx_written += 1;
+                } else {
+                    stats.cache.tsx_skipped += 1;
+                }
+                cache_files.insert(full_path.clone());
+                tsconfig_files.push(full_path.clone());
             }
-            cache_files.insert(full_path.clone());
-            tsconfig_files.push(full_path.clone());
 
             if let Some(file_name) = full_path.file_name() {
                 let stub_path = full_path.with_extension("d.ts");
-                let stub_content = format!(
-                    "export * from \"./{}\";\nexport {{ default }} from \"./{}\";\n",
-                    file_name, file_name
-                );
+                let stub_content = file.declaration_content.clone().unwrap_or_else(|| {
+                    format!(
+                        "export * from \"./{}\";\nexport {{ default }} from \"./{}\";\n",
+                        file_name, file_name
+                    )
+                });
                 let wrote = write_if_changed(&stub_path, stub_content.as_bytes(), "write stub")?;
                 if wrote {
                     stats.cache.stub_written += 1;
@@ -1487,6 +1504,7 @@ impl TsgoRunner {
 
         // Generate a standalone tsconfig overlay with rootDirs and absolute paths.
         let project_tsconfig = self.resolve_tsconfig_path()?;
+        let extra_root_dir = common_external_root_dir(&self.project_root, files);
         let tsconfig_start = Instant::now();
         let overlay_options = TsconfigOverlayOptions {
             temp_root: temp_path.as_path(),
@@ -1495,6 +1513,7 @@ impl TsgoRunner {
             kit_include: kit_include.as_deref(),
             patched_sources: &patched_sources,
             extra_files: &tsconfig_files,
+            extra_root_dir,
         };
         let temp_tsconfig = self.prepare_tsconfig_overlay(&overlay_options, &mut stats.cache)?;
         stats.timings.tsconfig_time = tsconfig_start.elapsed();
@@ -1730,6 +1749,33 @@ fn to_forward_slash(path: &Utf8Path) -> String {
     } else {
         s.to_string()
     }
+}
+
+fn common_external_root_dir(
+    project_root: &Utf8Path,
+    files: &TransformedFiles,
+) -> Option<Utf8PathBuf> {
+    let mut common = clean_path(project_root);
+    let mut saw_external = false;
+    for file in files.files.values() {
+        if file.original_path.starts_with(project_root) {
+            continue;
+        }
+        saw_external = true;
+        common = common_path_prefix(&common, &clean_path(&file.original_path));
+    }
+    saw_external.then_some(common)
+}
+
+fn common_path_prefix(a: &Utf8Path, b: &Utf8Path) -> Utf8PathBuf {
+    let mut out = Utf8PathBuf::new();
+    for (left, right) in a.components().zip(b.components()) {
+        if left != right {
+            break;
+        }
+        out.push(left.as_str());
+    }
+    out
 }
 
 fn clean_path(path: &Utf8Path) -> Utf8PathBuf {
@@ -2196,6 +2242,8 @@ pub struct TransformedFile {
     pub original_path: Utf8PathBuf,
     /// The generated TSX content.
     pub tsx_content: String,
+    /// Optional declaration content to write instead of generated TSX.
+    pub declaration_content: Option<String>,
     /// Line index for the generated content (for fast source mapping).
     pub generated_line_index: source_map::LineIndex,
     /// The source map for position mapping.
@@ -2403,6 +2451,7 @@ mod tests {
             TransformedFile {
                 original_path: Utf8PathBuf::from("src/App.svelte"),
                 tsx_content: "// generated".to_string(),
+                declaration_content: None,
                 generated_line_index: LineIndex::new("// generated"),
                 source_map: SourceMap::new(),
                 original_line_index: LineIndex::new(original_source),

--- a/test-fixtures/projects/workspace-stubs/app/package.json
+++ b/test-fixtures/projects/workspace-stubs/app/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "workspace-stubs-app",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@fixture/ui": "workspace:*"
+  }
+}

--- a/test-fixtures/projects/workspace-stubs/app/src/main.ts
+++ b/test-fixtures/projects/workspace-stubs/app/src/main.ts
@@ -1,0 +1,8 @@
+import Fancy, { theme, type FancyProps } from '@fixture/ui/fancy';
+
+const props: FancyProps = { label: 'Hello' };
+const selectedTheme: string = theme;
+
+void Fancy;
+void props;
+void selectedTheme;

--- a/test-fixtures/projects/workspace-stubs/app/tsconfig.json
+++ b/test-fixtures/projects/workspace-stubs/app/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "target": "ES2022",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "noEmit": true,
+    "paths": {
+      "@fixture/ui/fancy": ["../ui/src/Fancy.svelte"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/test-fixtures/projects/workspace-stubs/package.json
+++ b/test-fixtures/projects/workspace-stubs/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "workspaces": ["app", "ui"],
+  "devDependencies": {
+    "@typescript/native-preview": "7.0.0-dev.20260224.1",
+    "svelte": "^5.45.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/test-fixtures/projects/workspace-stubs/ui/package.json
+++ b/test-fixtures/projects/workspace-stubs/ui/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/ui",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/test-fixtures/projects/workspace-stubs/ui/src/Fancy.svelte
+++ b/test-fixtures/projects/workspace-stubs/ui/src/Fancy.svelte
@@ -1,0 +1,10 @@
+<script module lang="ts">
+	export type FancyProps = { label: string };
+	export const theme = 'blue';
+</script>
+
+<script lang="ts">
+	let { label }: FancyProps = $props();
+</script>
+
+<p>{label}</p>

--- a/test-fixtures/projects/workspace-stubs/ui/src/Fancy.svelte.ts
+++ b/test-fixtures/projects/workspace-stubs/ui/src/Fancy.svelte.ts
@@ -1,0 +1,3 @@
+// Companion rune module with the same basename as Fancy.svelte.
+// App checks should not let this file overwrite the component declaration stub.
+export const helper = $state({ count: 0 });

--- a/test-fixtures/projects/workspace-stubs/ui/src/index.ts
+++ b/test-fixtures/projects/workspace-stubs/ui/src/index.ts
@@ -1,0 +1,3 @@
+import Fancy, { theme, type FancyProps } from './Fancy.svelte';
+
+export { Fancy, theme, type FancyProps };


### PR DESCRIPTION
## Summary

When checking a package inside a package-manager workspace, generate declaration-only stubs for Svelte files discovered in sibling workspace packages.

## Why

TypeScript can resolve imports into local workspace packages while the checker is run from an app/package subdirectory. Those imported `.svelte` components need module shape information, but the checker should keep diagnostics scoped to the requested workspace instead of fully checking every sibling package.

This change provides enough `.d.ts` shape for imports while avoiding full generated TS checks and compiler diagnostics for external workspace files.

## Details

- Detect the nearest package-manager workspace root.
- Discover Svelte files from that root in addition to the requested workspace.
- Emit declaration-only stubs for external workspace Svelte components/modules.
- Keep full transforms and diagnostics for files inside the requested workspace.
- Add an integration fixture for an app importing a sibling workspace package Svelte component with named exports.

## Testing

- `cargo test -p svelte-check-rs --test integration_workspace_stubs`
- `cargo test -p tsgo-runner test_transformed_files`
- `cargo build -p svelte-check-rs`