### PR TITLE
fix(tsgo): use typescript 7 package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,9 @@ Rust drop-in replacement for `svelte-check` (**Svelte 5+ only**).
 6. **Type-check**: Send all transformed files to `tsgo` subprocess, map errors back via source maps
 
 **tsgo Integration** (tsgo-runner crate):
-- External TypeScript type-checker (Go-based, faster than tsc)
+- External TypeScript type-checker from `typescript@^7`
 - Resolved from workspace `node_modules/.bin` (walks up from `--workspace`)
-- Requires `@typescript/native-preview` to be installed in the workspace (peer dependency range: `>=7.0.0-dev.0`)
+- Requires `typescript` to be installed in the workspace (peer dependency range: `>=7.0.0`)
 - Communication: JSON over stdin/stdout
 - Incremental builds via `node_modules/.cache/svelte-check-rs/tsgo.tsbuildinfo`
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ svelte-check-rs --output human-verbose
 
 ## Requirements
 
-`svelte-check-rs` expects `tsgo` to be available from your workspace `node_modules`. Install it via:
+`svelte-check-rs` expects `typescript@^7` to be available from your workspace `node_modules`. Install it via:
 
 ```bash
-npm install -D @typescript/native-preview
+npm install -D typescript@^7
 ```
 
 Some package managers (for example, bun) may auto-install peer dependencies, but explicit installation is always supported.

--- a/crates/svelte-check-rs/src/main.rs
+++ b/crates/svelte-check-rs/src/main.rs
@@ -122,13 +122,13 @@ fn print_debug_paths(workspace: &Utf8Path) {
     println!("Workspace: {}", workspace);
     println!();
 
-    // tsgo binary
-    println!("tsgo:");
+    // typescript package binary
+    println!("typescript:");
     match TsgoRunner::resolve_tsgo(&workspace) {
         Ok(path) => println!("  resolved: {}", path),
         Err(_) => {
             println!(
-                "  resolved: (not found - install @typescript/native-preview in your workspace)"
+                "  resolved: (not found - install typescript@^7 in your workspace)"
             );
         }
     }

--- a/crates/svelte-check-rs/tests/integration_cache.rs
+++ b/crates/svelte-check-rs/tests/integration_cache.rs
@@ -99,8 +99,8 @@ fn cache_root(fixture_path: &std::path::Path) -> PathBuf {
 /// Ensures dependencies are installed for a fixture.
 fn ensure_fixture_deps(fixture_path: &PathBuf) {
     let node_modules = fixture_path.join("node_modules");
-    let tsgo_bin = node_modules.join(".bin/tsgo");
-    if !node_modules.exists() || !tsgo_bin.exists() {
+    let tsc_bin = node_modules.join(".bin/tsc");
+    if !node_modules.exists() || !tsc_bin.exists() {
         let bun_path = bun_path_for(fixture_path);
         let output = Command::new(bun_path.as_std_path())
             .arg("install")

--- a/crates/svelte-check-rs/tests/integration_external_imports.rs
+++ b/crates/svelte-check-rs/tests/integration_external_imports.rs
@@ -121,8 +121,8 @@ fn ensure_fixture_ready(fixture_path: &PathBuf) {
         let _ = fs::remove_dir_all(&cache_path);
 
         let node_modules = fixture_path.join("node_modules");
-        let tsgo_bin = node_modules.join(".bin/tsgo");
-        if !node_modules.exists() || !tsgo_bin.exists() {
+        let tsc_bin = node_modules.join(".bin/tsc");
+        if !node_modules.exists() || !tsc_bin.exists() {
             eprintln!("Installing dependencies for sveltekit-bundler...");
             let bun_path = bun_path_for(fixture_path);
             let output = Command::new(bun_path.as_std_path())

--- a/crates/svelte-check-rs/tests/integration_issues.rs
+++ b/crates/svelte-check-rs/tests/integration_issues.rs
@@ -111,10 +111,10 @@ fn ensure_fixture_ready(fixture_path: &PathBuf, ready: &'static OnceLock<()>) {
         let cache_path = cache_root(fixture_path);
         let _ = fs::remove_dir_all(&cache_path);
 
-        // Check if node_modules and tsgo exist
+        // Check if node_modules and the typescript binary exist
         let node_modules = fixture_path.join("node_modules");
-        let tsgo_bin = node_modules.join(".bin/tsgo");
-        if !node_modules.exists() || !tsgo_bin.exists() {
+        let tsc_bin = node_modules.join(".bin/tsc");
+        if !node_modules.exists() || !tsc_bin.exists() {
             eprintln!("Installing dependencies for sveltekit-bundler...");
 
             let bun_path = bun_path_for(fixture_path);
@@ -721,10 +721,10 @@ fn ensure_modules_fixture_ready(fixture_path: &PathBuf) {
         let cache_path = cache_root(fixture_path);
         let _ = fs::remove_dir_all(&cache_path);
 
-        // Check if node_modules and tsgo exist
+        // Check if node_modules and the typescript binary exist
         let node_modules = fixture_path.join("node_modules");
-        let tsgo_bin = node_modules.join(".bin/tsgo");
-        if !node_modules.exists() || !tsgo_bin.exists() {
+        let tsc_bin = node_modules.join(".bin/tsc");
+        if !node_modules.exists() || !tsc_bin.exists() {
             eprintln!("Installing dependencies for svelte-modules...");
 
             let bun_path = bun_path_for(fixture_path);

--- a/crates/svelte-check-rs/tests/integration_parity.rs
+++ b/crates/svelte-check-rs/tests/integration_parity.rs
@@ -129,8 +129,8 @@ fn ensure_fixture_ready(fixture_path: &PathBuf) {
         let _ = fs::remove_dir_all(&cache_path);
 
         let node_modules = fixture_path.join("node_modules");
-        let tsgo_bin = node_modules.join(".bin/tsgo");
-        if !node_modules.exists() || !tsgo_bin.exists() {
+        let tsc_bin = node_modules.join(".bin/tsc");
+        if !node_modules.exists() || !tsc_bin.exists() {
             eprintln!("Installing dependencies for sveltekit-bundler...");
             let bun_path = bun_path_for(fixture_path);
             let output = Command::new(bun_path.as_std_path())

--- a/crates/svelte-check-rs/tests/integration_snippet_generics.rs
+++ b/crates/svelte-check-rs/tests/integration_snippet_generics.rs
@@ -102,10 +102,10 @@ fn ensure_fixture_ready(fixture_path: &PathBuf, ready: &'static OnceLock<()>) {
         let cache_path = cache_root(fixture_path);
         let _ = fs::remove_dir_all(&cache_path);
 
-        // Check if node_modules and tsgo exist
+        // Check if node_modules and the typescript binary exist
         let node_modules = fixture_path.join("node_modules");
-        let tsgo_bin = node_modules.join(".bin/tsgo");
-        if !node_modules.exists() || !tsgo_bin.exists() {
+        let tsc_bin = node_modules.join(".bin/tsc");
+        if !node_modules.exists() || !tsc_bin.exists() {
             eprintln!("Installing dependencies for sveltekit-bundler...");
 
             let bun_path = bun_path_for(fixture_path);

--- a/crates/svelte-check-rs/tests/integration_tsconfig.rs
+++ b/crates/svelte-check-rs/tests/integration_tsconfig.rs
@@ -130,10 +130,10 @@ fn ensure_fixture_ready(fixture_name: &str, ready: &'static OnceLock<()>) {
         let cache_path = cache_root(&fixture_path);
         let _ = std::fs::remove_dir_all(&cache_path);
 
-        // Check if node_modules and tsgo exist
+        // Check if node_modules and the typescript binary exist
         let node_modules = fixture_path.join("node_modules");
-        let tsgo_bin = node_modules.join(".bin/tsgo");
-        if !node_modules.exists() || !tsgo_bin.exists() {
+        let tsc_bin = node_modules.join(".bin/tsc");
+        if !node_modules.exists() || !tsc_bin.exists() {
             eprintln!("Installing dependencies for {}...", fixture_name);
 
             let bun_path = bun_path_for(&fixture_path);

--- a/crates/tsgo-runner/src/runner.rs
+++ b/crates/tsgo-runner/src/runner.rs
@@ -18,6 +18,8 @@ use walkdir::WalkDir;
 const SHARED_HELPERS_FILENAME: &str = "__svelte_check_rs_helpers.d.ts";
 const DEP_CACHE_MANIFEST_FILENAME: &str = "deps.manifest.json";
 const DEP_CACHE_MANIFEST_VERSION: u32 = 1;
+const TYPESCRIPT_PACKAGE_NAME: &str = "typescript";
+const TYPESCRIPT_PACKAGE_RANGE: &str = ">=7.0.0";
 const SHARED_HELPERS_DTS: &str = r#"import type { Component as SvelteComponentType, ComponentInternals as SvelteComponentInternals, Snippet as SvelteSnippet, SvelteComponent as SvelteLegacyComponent } from "svelte";
 import type { SvelteHTMLElements as SvelteHTMLElements, HTMLAttributes as SvelteHTMLAttributes } from "svelte/elements";
 
@@ -216,7 +218,9 @@ pub enum TsgoError {
 
     /// tsgo not installed in node_modules.
     #[error(
-        "tsgo not found in node_modules starting at {0}. Install @typescript/native-preview in your workspace (some package managers may auto-install peer dependencies)."
+        "typescript not found in node_modules starting at {0}. Install {package}@\"{range}\" in your workspace (some package managers may auto-install peer dependencies).",
+        package = TYPESCRIPT_PACKAGE_NAME,
+        range = TYPESCRIPT_PACKAGE_RANGE
     )]
     TsgoNotInstalled(Utf8PathBuf),
 
@@ -443,17 +447,22 @@ impl TsgoRunner {
             .to_string()
     }
 
-    /// Resolves tsgo from node_modules/.bin by walking up from the workspace root.
+    /// Resolves the typescript package binary from node_modules/.bin by walking up
+    /// from the workspace root.
     ///
     /// On Windows, `Command::new` cannot execute the extensionless Unix shell
     /// shim that npm/pnpm/yarn install alongside `.cmd`/`.exe`; CreateProcess
     /// rejects it with `%1 is not a valid Win32 application` (os error 193).
     /// Probe only platform-executable extensions on Windows.
     pub fn resolve_tsgo(workspace_root: &Utf8Path) -> Result<Utf8PathBuf, TsgoError> {
+        // Prefer typescript@^7's tsc shim; keep tsgo as a compatibility
+        // fallback for workspaces still using @typescript/native-preview.
         const SHIM_CANDIDATES: &[&str] = if cfg!(windows) {
-            &["tsgo.exe", "tsgo.cmd", "tsgo.bat"]
+            &[
+                "tsc.exe", "tsc.cmd", "tsc.bat", "tsgo.exe", "tsgo.cmd", "tsgo.bat",
+            ]
         } else {
-            &["tsgo"]
+            &["tsc", "tsgo"]
         };
 
         let mut current = Some(workspace_root);

--- a/npm/base/package.json
+++ b/npm/base/package.json
@@ -18,6 +18,6 @@
   ],
   "optionalDependencies": {},
   "peerDependencies": {
-    "@typescript/native-preview": ">=7.0.0-dev.0"
+    "typescript": ">=7.0.0"
   }
 }

--- a/test-fixtures/projects/bind-shorthand/package.json
+++ b/test-fixtures/projects/bind-shorthand/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@typescript/native-preview": "7.0.0-dev.20260224.1",
-    "svelte": "^5.45.6"
+    "svelte": "^5.45.6",
+    "typescript": "^7.0.2"
   }
 }

--- a/test-fixtures/projects/svelte-modules/package.json
+++ b/test-fixtures/projects/svelte-modules/package.json
@@ -12,13 +12,12 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@typescript/native-preview": "7.0.0-dev.20260224.1",
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/kit": "^2.49.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"svelte": "^5.45.6",
 		"svelte-check": "^4.3.4",
-		"typescript": "^5.9.3",
+		"typescript": "^7.0.2",
 		"vite": "^7.2.6"
 	}
 }

--- a/test-fixtures/projects/sveltekit-bundler/package.json
+++ b/test-fixtures/projects/sveltekit-bundler/package.json
@@ -12,13 +12,12 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@typescript/native-preview": "7.0.0-dev.20260224.1",
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/kit": "^2.49.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"svelte": "^5.45.6",
 		"svelte-check": "^4.3.4",
-		"typescript": "^5.9.3",
+		"typescript": "^7.0.2",
 		"vite": "^7.2.6"
 	}
 }

--- a/test-fixtures/projects/sveltekit-node16/package.json
+++ b/test-fixtures/projects/sveltekit-node16/package.json
@@ -12,13 +12,12 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@typescript/native-preview": "7.0.0-dev.20260224.1",
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/kit": "^2.49.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"svelte": "^5.45.6",
 		"svelte-check": "^4.3.4",
-		"typescript": "^5.9.3",
+		"typescript": "^7.0.2",
 		"vite": "^7.2.6"
 	}
 }

--- a/test-fixtures/projects/sveltekit-nodenext/package.json
+++ b/test-fixtures/projects/sveltekit-nodenext/package.json
@@ -12,13 +12,12 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@typescript/native-preview": "7.0.0-dev.20260224.1",
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/kit": "^2.49.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"svelte": "^5.45.6",
 		"svelte-check": "^4.3.4",
-		"typescript": "^5.9.3",
+		"typescript": "^7.0.2",
 		"vite": "^7.2.6"
 	}
 }


### PR DESCRIPTION
- switch the npm peer dependency from `@typescript/native-preview` to `typescript >=7.0.0` (https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-rc/#nightly-releases) as the full release is out
- resolve `typescript@^7`'s `.bin/tsc` shim before falling back to the legacy `tsgo` shim
- update fixtures, docs, debug output, and integration-test install checks for the new package