### PR TITLE
fix(transformer): expose component instance types

### DIFF
--- a/crates/svelte-check-rs/tests/integration_issues.rs
+++ b/crates/svelte-check-rs/tests/integration_issues.rs
@@ -279,6 +279,29 @@ where
 }
 
 // ============================================================================
+// COMPONENT VALUES AS INSTANCE TYPES
+// ============================================================================
+
+/// A generated Svelte component's default export occupies both TypeScript's
+/// value and type namespaces, matching svelte2tsx. Cover direct type imports,
+/// multi-level named barrel re-exports, generics, JavaScript components,
+/// scriptless and legacy components, and `bind:this` in one full-pipeline fixture.
+#[test]
+fn test_component_values_are_usable_as_precise_instance_types() {
+    let fixture_path = fixtures_dir().join("sveltekit-bundler");
+    let (_exit_code, diagnostics) = run_check_json(&fixture_path);
+
+    let fixture_diagnostics: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.filename.contains("component-instance-types/"))
+        .collect();
+    assert!(
+        fixture_diagnostics.is_empty(),
+        "component instance type fixture produced diagnostics:\n{fixture_diagnostics:#?}",
+    );
+}
+
+// ============================================================================
 // ISSUE #21: COLON IN IMPORTS
 // ============================================================================
 // These tests verify that colons in import paths, string literals, and regex

--- a/crates/svelte-transformer/src/component_exports.rs
+++ b/crates/svelte-transformer/src/component_exports.rs
@@ -20,11 +20,12 @@ pub struct ExportedName {
 ///
 /// This looks for export declarations including:
 /// - `export { ... }` named re-exports
-/// - `export const/let/var name = ...` variable declarations
+/// - `export const name = ...` variable declarations
 /// - `export function name() {}` function declarations
 /// - `export class Name {}` class declarations
 ///
-/// Ignores type-only exports and re-exports with `from`.
+/// Ignores legacy `export let`/`export var` props, type-only exports, and
+/// re-exports with `from`.
 pub fn extract_component_exports(script: &str) -> Vec<ExportedName> {
     let Some(module) = parse_module(script) else {
         return Vec::new();
@@ -51,24 +52,20 @@ pub fn extract_component_exports(script: &str) -> Vec<ExportedName> {
                 }
             }
             ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
-                // Handle: export const/let/var, export function, export class
+                // Handle: export const, export function, export class
                 match &export_decl.decl {
                     Decl::Var(var_decl) => {
                         // Skip `declare` statements (e.g., `export declare const foo: Type`)
-                        if var_decl.declare {
+                        // and mutable declarations, which are legacy component props.
+                        if var_decl.declare || var_decl.kind != VarDeclKind::Const {
                             continue;
                         }
-                        if var_decl.kind == VarDeclKind::Const
-                            || var_decl.kind == VarDeclKind::Let
-                            || var_decl.kind == VarDeclKind::Var
-                        {
-                            for decl in &var_decl.decls {
-                                if let Some(name) = extract_binding_name(&decl.name) {
-                                    exports.push(ExportedName {
-                                        exported: name.clone(),
-                                        local: name,
-                                    });
-                                }
+                        for decl in &var_decl.decls {
+                            if let Some(name) = extract_binding_name(&decl.name) {
+                                exports.push(ExportedName {
+                                    exported: name.clone(),
+                                    local: name,
+                                });
                             }
                         }
                     }
@@ -250,11 +247,10 @@ mod tests {
     }
 
     #[test]
-    fn extracts_export_let() {
-        let script = "export let value = 42;";
+    fn ignores_legacy_prop_declarations() {
+        let script = "export let value = 42; export var other = true;";
         let exports = extract_component_exports(script);
-        assert_eq!(exports.len(), 1);
-        assert_eq!(exports[0].exported, "value");
+        assert!(exports.is_empty());
     }
 
     #[test]

--- a/crates/svelte-transformer/src/transform.rs
+++ b/crates/svelte-transformer/src/transform.rs
@@ -770,6 +770,7 @@ fn extract_attribute_text(value: &AttributeValue) -> Option<String> {
 struct GenericParam {
     name: String,
     definition: String,
+    type_definition: String,
 }
 
 fn parse_generic_declarations(generics: &str) -> Vec<GenericParam> {
@@ -782,11 +783,21 @@ fn parse_generic_declarations(generics: &str) -> Vec<GenericParam> {
                 return None;
             }
 
+            // `const` modifiers are valid on function type parameters, but not
+            // on type aliases. Preserve the original declaration for the
+            // component call signature and strip it for the merged type alias.
+            let type_definition = match param.strip_prefix("const") {
+                Some(rest) if rest.chars().next().is_some_and(char::is_whitespace) => {
+                    rest.trim_start()
+                }
+                _ => param,
+            };
+
             // Extract name up to first whitespace or '='
-            let name_end = param
+            let name_end = type_definition
                 .find(|c: char| c.is_whitespace() || c == '=')
-                .unwrap_or(param.len());
-            let name = param[..name_end].trim().to_string();
+                .unwrap_or(type_definition.len());
+            let name = type_definition[..name_end].trim().to_string();
             if name.is_empty() {
                 return None;
             }
@@ -794,6 +805,7 @@ fn parse_generic_declarations(generics: &str) -> Vec<GenericParam> {
             Some(GenericParam {
                 name,
                 definition: param.to_string(),
+                type_definition: type_definition.to_string(),
             })
         })
         .collect()
@@ -832,6 +844,18 @@ fn generics_def(params: &[GenericParam]) -> String {
     let defs = params
         .iter()
         .map(|param| param.definition.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("<{}>", defs)
+}
+
+fn generics_type_def(params: &[GenericParam]) -> String {
+    if params.is_empty() {
+        return String::new();
+    }
+    let defs = params
+        .iter()
+        .map(|param| param.type_definition.as_str())
         .collect::<Vec<_>>()
         .join(", ");
     format!("<{}>", defs)
@@ -1658,6 +1682,7 @@ pub fn transform(doc: &SvelteDocument, options: TransformOptions) -> TransformRe
     generic_decls.retain(|param| !declared_types.contains(&param.name));
     let has_generics = !generic_decls.is_empty();
     let generics_def_str = generics_def(&generic_decls);
+    let generics_type_def_str = generics_type_def(&generic_decls);
     let generics_ref_str = generics_ref(&generic_decls);
 
     let helpers_import_path = options.helpers_import_path.as_deref();
@@ -1722,6 +1747,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
     let helpers = r#"// Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -1730,7 +1760,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -2233,17 +2263,19 @@ declare module "svelte" {
         let internal_name = format!("__SvelteComponent_{}_", component_name);
         let props_name = format!("__SvelteProps_{}_", component_name);
         format!(
-            "type {props_name}{generics_def} = Awaited<ReturnType<typeof __svelte_render{generics_ref}>>[\"props\"];\n\
+            "type {props_name}{generics_type_def} = Awaited<ReturnType<typeof __svelte_render{generics_ref}>>[\"props\"];\n\
 declare const {internal_name}: {{\n\
-  {generics_def}(this: void, internals: any, props: {props_name}{generics_ref} & __SvelteCssProps): Awaited<ReturnType<typeof __svelte_render{generics_ref}>>[\"exports\"];\n\
+  {generics_def}(this: void, internals: any, props: {props_name}{generics_ref} & __SvelteCssProps): __SvelteComponentInstance<{props_name}{generics_ref}, Awaited<ReturnType<typeof __svelte_render{generics_ref}>>[\"exports\"]>;\n\
   __svelte_generic: true;\n\
   element?: typeof HTMLElement;\n\
   z_$$bindings?: any;\n\
 }};\n\
+type {internal_name}{generics_type_def} = ReturnType<typeof {internal_name}{generics_ref}>;\n\
 export default {internal_name};\n",
             props_name = props_name,
             internal_name = internal_name,
             generics_def = generics_def_str,
+            generics_type_def = generics_type_def_str,
             generics_ref = generics_ref_str
         )
     } else if has_render {
@@ -2254,6 +2286,7 @@ export default {internal_name};\n",
             "type {props_name} = Awaited<ReturnType<typeof __svelte_render>>[\"props\"];\n\
 type {exports_name} = Awaited<ReturnType<typeof __svelte_render>>[\"exports\"];\n\
 declare const {internal_name}: __SvelteComponent<{props_name}, {exports_name}>;\n\
+type {internal_name} = ReturnType<typeof {internal_name}>;\n\
 export default {internal_name};\n",
             props_name = props_name,
             exports_name = exports_name,
@@ -2378,6 +2411,49 @@ mod tests {
             rewrite_svelte_imports(r#"import X from "./other.ts""#),
             r#"import X from "./other.ts""#
         );
+    }
+
+    #[test]
+    fn test_const_generic_declarations() {
+        let params = parse_generic_declarations(
+            "const T extends { id: string } = { id: string }, U = keyof T",
+        );
+
+        assert_eq!(
+            generics_def(&params),
+            "<const T extends { id: string } = { id: string }, U = keyof T>"
+        );
+        assert_eq!(
+            generics_type_def(&params),
+            "<T extends { id: string } = { id: string }, U = keyof T>"
+        );
+        assert_eq!(generics_ref(&params), "<T, U>");
+    }
+
+    #[test]
+    fn test_legacy_props_are_not_instance_exports() {
+        let doc = parse(
+            r#"<script lang="ts">
+                export let value: string = "";
+            </script>
+            <span>{value}</span>"#,
+        )
+        .document;
+        let result = transform(
+            &doc,
+            TransformOptions {
+                filename: Some("LegacyTarget.svelte".to_string()),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(result.exports.exports_type, None);
+        let export_section = result
+            .tsx_code
+            .split_once("// === COMPONENT TYPE EXPORT ===")
+            .expect("component type export section")
+            .1;
+        assert!(!export_section.contains("value"));
     }
 
     #[test]

--- a/crates/svelte-transformer/src/types.rs
+++ b/crates/svelte-transformer/src/types.rs
@@ -54,7 +54,8 @@ impl ComponentExports {
     ///
     /// Produces output like:
     /// ```text
-    /// declare const __SvelteComponent_Counter_: Component<Props>;
+    /// declare const __SvelteComponent_Counter_: __SvelteComponent<Props>;
+    /// type __SvelteComponent_Counter_ = ReturnType<typeof __SvelteComponent_Counter_>;
     /// export default __SvelteComponent_Counter_;
     /// ```
     pub fn generate_typescript_export(&self, component_name: &str) -> String {
@@ -63,8 +64,10 @@ impl ComponentExports {
         let props_type = format!("__SvelteLoosen<{}>", self.props_or_default());
         if self.exports_type.is_none() {
             return format!(
-                "type {} = {};\ndeclare const {}: __SvelteComponent<{}>;\nexport default {};\n",
-                props_name, props_type, internal_name, props_name, internal_name
+                "type {props_name} = {props_type};\n\
+declare const {internal_name}: __SvelteComponent<{props_name}>;\n\
+type {internal_name} = ReturnType<typeof {internal_name}>;\n\
+export default {internal_name};\n"
             );
         }
         let exports_name = format!("__SvelteExports_{}_", component_name);
@@ -72,6 +75,7 @@ impl ComponentExports {
             "type {props_name} = {props_type};\n\
 type {exports_name} = {exports_type};\n\
 declare const {internal_name}: __SvelteComponent<{props_name}, {exports_name}>;\n\
+type {internal_name} = ReturnType<typeof {internal_name}>;\n\
 export default {internal_name};\n",
             props_name = props_name,
             props_type = props_type,
@@ -87,7 +91,8 @@ export default {internal_name};\n",
     ///
     /// Produces output like:
     /// ```text
-    /// declare const __SvelteComponent_Counter_: Component<{}>;
+    /// declare const __SvelteComponent_Counter_: __SvelteComponent<{}>;
+    /// type __SvelteComponent_Counter_ = ReturnType<typeof __SvelteComponent_Counter_>;
     /// export default __SvelteComponent_Counter_;
     /// ```
     pub fn generate_javascript_export(&self, component_name: &str) -> String {
@@ -96,8 +101,10 @@ export default {internal_name};\n",
         let props_type = "__SvelteLoosen<{}>";
         if self.exports_type.is_none() {
             return format!(
-                "type {} = {};\ndeclare const {}: __SvelteComponent<{}>;\nexport default {};\n",
-                props_name, props_type, internal_name, props_name, internal_name
+                "type {props_name} = {props_type};\n\
+declare const {internal_name}: __SvelteComponent<{props_name}>;\n\
+type {internal_name} = ReturnType<typeof {internal_name}>;\n\
+export default {internal_name};\n"
             );
         }
         let exports_name = format!("__SvelteExports_{}_", component_name);
@@ -105,6 +112,7 @@ export default {internal_name};\n",
             "type {props_name} = {props_type};\n\
 type {exports_name} = {exports_type};\n\
 declare const {internal_name}: __SvelteComponent<{props_name}, {exports_name}>;\n\
+type {internal_name} = ReturnType<typeof {internal_name}>;\n\
 export default {internal_name};\n",
             props_name = props_name,
             props_type = props_type,
@@ -211,6 +219,9 @@ mod tests {
         assert!(
             export_line.contains("declare const __SvelteComponent_Counter_: __SvelteComponent<")
         );
+        assert!(export_line.contains(
+            "type __SvelteComponent_Counter_ = ReturnType<typeof __SvelteComponent_Counter_>;"
+        ));
         assert!(export_line.contains("{ count: number }"));
         assert!(export_line.contains("export default __SvelteComponent_Counter_"));
     }
@@ -223,6 +234,9 @@ mod tests {
         assert!(export_line.contains("type __SvelteProps_Button_ = __SvelteLoosen<{}>;"));
         assert!(export_line.contains(
             "declare const __SvelteComponent_Button_: __SvelteComponent<__SvelteProps_Button_>"
+        ));
+        assert!(export_line.contains(
+            "type __SvelteComponent_Button_ = ReturnType<typeof __SvelteComponent_Button_>;"
         ));
         assert!(export_line.contains("export default __SvelteComponent_Button_"));
     }

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_component.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_component.snap
@@ -32,6 +32,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -40,7 +45,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -207,6 +212,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_element.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_element.snap
@@ -25,6 +25,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -33,7 +38,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -189,6 +194,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_inline.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_inline.snap
@@ -27,6 +27,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -35,7 +40,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -192,6 +197,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__attach_source_mapping.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__attach_source_mapping.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -178,9 +183,10 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 
 === Source Map Mappings (2) ===
-  0: generated 6643..6703 -> original 18..78
-  1: generated 6765..6773 -> original 103..111
+  0: generated 6840..6900 -> original 18..78
+  1: generated 6962..6970 -> original 103..111

--- a/crates/svelte-transformer/tests/snapshots/snapshots__await_components.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__await_components.snap
@@ -31,6 +31,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -39,7 +44,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -220,6 +225,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__await_then_wrong_annotation.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__await_then_wrong_annotation.snap
@@ -24,6 +24,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -32,7 +37,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -193,6 +198,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bind_key_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bind_key_transform.snap
@@ -21,6 +21,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -29,7 +34,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -184,6 +189,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bind_shorthand_component.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bind_shorthand_component.snap
@@ -21,6 +21,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -29,7 +34,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -185,6 +190,7 @@ return { props: null as any as __SvelteOptionalProps<{ selectedIds: string[] }, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bind_shorthand_element.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bind_shorthand_element.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -181,6 +186,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bind_this_getter_setter_pair.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bind_this_getter_setter_pair.snap
@@ -23,6 +23,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -31,7 +36,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -185,6 +190,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bind_value_component_expression.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bind_value_component_expression.snap
@@ -21,6 +21,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -29,7 +34,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -184,6 +189,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bind_with_getter_setter_pair.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bind_with_getter_setter_pair.snap
@@ -23,6 +23,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -31,7 +36,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -188,6 +193,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bindable_props_with_comments.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bindable_props_with_comments.snap
@@ -29,6 +29,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -37,7 +42,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -204,6 +209,7 @@ return { props: null as any as __SvelteOptionalProps<{
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bindable_renamed_marker.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bindable_renamed_marker.snap
@@ -18,6 +18,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -26,7 +31,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -174,6 +179,7 @@ return { props: null as any as __SvelteOptionalProps<{ class?: string }, "class"
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__bindable_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__bindable_rune.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -182,6 +187,7 @@ return { props: null as any as __SvelteOptionalProps<{ value?: string }, "value"
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__binding_checked.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__binding_checked.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -182,6 +187,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__binding_value.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__binding_value.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -181,6 +186,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__class_shorthand_element.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__class_shorthand_element.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -178,6 +183,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__comment_in_attr_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__comment_in_attr_transform.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -180,6 +185,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__complex_events.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__complex_events.snap
@@ -45,6 +45,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -53,7 +58,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -226,6 +231,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__complex_props_trajectory_pattern.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__complex_props_trajectory_pattern.snap
@@ -47,6 +47,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -55,7 +60,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -257,6 +262,7 @@ return { props: null as any as EventHandlers & {
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__component_css_custom_props.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__component_css_custom_props.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -181,6 +186,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__component_namespace.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__component_namespace.snap
@@ -37,6 +37,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -45,7 +50,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -246,6 +251,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__component_snippet_generic_header.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__component_snippet_generic_header.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -180,6 +185,7 @@ async function __svelte_template_check__() {
 // === COMPONENT TYPE EXPORT ===
 type __SvelteProps_Test_ = __SvelteLoosen<{}>;
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__component_snippets_props.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__component_snippets_props.snap
@@ -43,6 +43,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -51,7 +56,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -222,6 +227,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__conditional_components.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__conditional_components.snap
@@ -35,6 +35,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -43,7 +48,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -216,6 +221,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__const_arrow_function_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__const_arrow_function_transform.snap
@@ -24,6 +24,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -32,7 +37,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -186,6 +191,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__const_iife_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__const_iife_transform.snap
@@ -29,6 +29,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -37,7 +42,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -196,6 +201,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__counter_complete.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__counter_complete.snap
@@ -36,6 +36,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -44,7 +49,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -212,6 +217,7 @@ return { props: null as any as __SvelteOptionalProps<{ initial?: number }, "init
 type __SvelteProps_Counter_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Counter_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Counter_: __SvelteComponent<__SvelteProps_Counter_, __SvelteExports_Counter_>;
+type __SvelteComponent_Counter_ = ReturnType<typeof __SvelteComponent_Counter_>;
 export default __SvelteComponent_Counter_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__declaration_tag_async.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__declaration_tag_async.snap
@@ -38,6 +38,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -46,7 +51,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -212,6 +217,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__declaration_tag_destructuring.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__declaration_tag_destructuring.snap
@@ -18,6 +18,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -26,7 +31,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -173,6 +178,7 @@ async function __svelte_template_check__() {
 // === COMPONENT TYPE EXPORT ===
 type __SvelteProps_Test_ = __SvelteLoosen<{}>;
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__declaration_tag_each.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__declaration_tag_each.snap
@@ -34,6 +34,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -42,7 +47,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -205,6 +210,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__declaration_tag_simple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__declaration_tag_simple.snap
@@ -17,6 +17,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -25,7 +30,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -171,6 +176,7 @@ async function __svelte_template_check__() {
 // === COMPONENT TYPE EXPORT ===
 type __SvelteProps_Test_ = __SvelteLoosen<{}>;
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__declaration_tag_source_map.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__declaration_tag_source_map.snap
@@ -17,6 +17,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -25,7 +30,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -171,9 +176,10 @@ async function __svelte_template_check__() {
 // === COMPONENT TYPE EXPORT ===
 type __SvelteProps_Test_ = __SvelteLoosen<{}>;
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 
 === Source Map Mappings (2) ===
-  0: generated 6717..6722 -> original 7..12
-  1: generated 6730..6735 -> original 19..24
+  0: generated 6914..6919 -> original 7..12
+  1: generated 6927..6932 -> original 19..24

--- a/crates/svelte-transformer/tests/snapshots/snapshots__derived_by_template_literal_comparison.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__derived_by_template_literal_comparison.snap
@@ -32,6 +32,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -40,7 +45,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -202,6 +207,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__derived_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__derived_rune.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -183,6 +188,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__dollar_callback_param_not_a_store.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__dollar_callback_param_not_a_store.snap
@@ -26,6 +26,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -34,7 +39,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -195,6 +200,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__dollar_member_access_not_a_store.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__dollar_member_access_not_a_store.snap
@@ -26,6 +26,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -34,7 +39,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -190,6 +195,7 @@ return { props: null as any as { selection: Selection }, exports: {}, slots: {},
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__each_complex_destructure_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__each_complex_destructure_transform.snap
@@ -33,6 +33,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -41,7 +46,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -208,6 +213,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__each_component_key.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__each_component_key.snap
@@ -37,6 +37,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -45,7 +50,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -213,6 +218,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__each_non_iterable.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__each_non_iterable.snap
@@ -26,6 +26,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -34,7 +39,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -193,6 +198,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__each_nullable.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__each_nullable.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -183,6 +188,7 @@ return { props: null as any as { items: number[] | null | undefined }, exports: 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__effect_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__effect_rune.snap
@@ -28,6 +28,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -36,7 +41,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -194,6 +199,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__empty_component.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__empty_component.snap
@@ -16,6 +16,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -24,7 +29,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -163,6 +168,7 @@ declare module "svelte" {
 // === COMPONENT TYPE EXPORT ===
 type __SvelteProps_Test_ = __SvelteLoosen<{}>;
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__event_inline.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__event_inline.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -180,6 +185,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__event_on_directive.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__event_on_directive.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -184,6 +189,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__event_reference.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__event_reference.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -184,6 +189,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__form_complete.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__form_complete.snap
@@ -35,6 +35,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -43,7 +48,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -221,6 +226,7 @@ return { props: null as any as { onsubmit: (data: { email: string; password: str
 type __SvelteProps_LoginForm_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_LoginForm_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_LoginForm_: __SvelteComponent<__SvelteProps_LoginForm_, __SvelteExports_LoginForm_>;
+type __SvelteComponent_LoginForm_ = ReturnType<typeof __SvelteComponent_LoginForm_>;
 export default __SvelteComponent_LoginForm_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__generic_multiple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__generic_multiple.snap
@@ -58,6 +58,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -66,7 +71,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -254,11 +259,12 @@ return { props: null as any as __SvelteOptionalProps<Props, "value" | "item">, e
 // === COMPONENT TYPE EXPORT ===
 type __SvelteProps_Combobox_<T extends {label: string; value: string}, TMode extends 'single' | 'multiple'> = Awaited<ReturnType<typeof __svelte_render<T, TMode>>>["props"];
 declare const __SvelteComponent_Combobox_: {
-<T extends {label: string; value: string}, TMode extends 'single' | 'multiple'>(this: void, internals: any, props: __SvelteProps_Combobox_<T, TMode> & __SvelteCssProps): Awaited<ReturnType<typeof __svelte_render<T, TMode>>>["exports"];
+<T extends {label: string; value: string}, TMode extends 'single' | 'multiple'>(this: void, internals: any, props: __SvelteProps_Combobox_<T, TMode> & __SvelteCssProps): __SvelteComponentInstance<__SvelteProps_Combobox_<T, TMode>, Awaited<ReturnType<typeof __svelte_render<T, TMode>>>["exports"]>;
 __svelte_generic: true;
 element?: typeof HTMLElement;
 z_$$bindings?: any;
 };
+type __SvelteComponent_Combobox_<T extends {label: string; value: string}, TMode extends 'single' | 'multiple'> = ReturnType<typeof __SvelteComponent_Combobox_<T, TMode>>;
 export default __SvelteComponent_Combobox_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__generic_placeholder_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__generic_placeholder_rune.snap
@@ -21,6 +21,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -29,7 +34,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -178,11 +183,12 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 // === COMPONENT TYPE EXPORT ===
 type __SvelteProps_Placeholder_<T> = Awaited<ReturnType<typeof __svelte_render<T>>>["props"];
 declare const __SvelteComponent_Placeholder_: {
-<T>(this: void, internals: any, props: __SvelteProps_Placeholder_<T> & __SvelteCssProps): Awaited<ReturnType<typeof __svelte_render<T>>>["exports"];
+<T>(this: void, internals: any, props: __SvelteProps_Placeholder_<T> & __SvelteCssProps): __SvelteComponentInstance<__SvelteProps_Placeholder_<T>, Awaited<ReturnType<typeof __svelte_render<T>>>["exports"]>;
 __svelte_generic: true;
 element?: typeof HTMLElement;
 z_$$bindings?: any;
 };
+type __SvelteComponent_Placeholder_<T> = ReturnType<typeof __SvelteComponent_Placeholder_<T>>;
 export default __SvelteComponent_Placeholder_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__generic_simple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__generic_simple.snap
@@ -27,6 +27,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -35,7 +40,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -197,11 +202,12 @@ return { props: null as any as __SvelteOptionalProps<{
 // === COMPONENT TYPE EXPORT ===
 type __SvelteProps_Select_<T extends { id: string; label: string }> = Awaited<ReturnType<typeof __svelte_render<T>>>["props"];
 declare const __SvelteComponent_Select_: {
-<T extends { id: string; label: string }>(this: void, internals: any, props: __SvelteProps_Select_<T> & __SvelteCssProps): Awaited<ReturnType<typeof __svelte_render<T>>>["exports"];
+<T extends { id: string; label: string }>(this: void, internals: any, props: __SvelteProps_Select_<T> & __SvelteCssProps): __SvelteComponentInstance<__SvelteProps_Select_<T>, Awaited<ReturnType<typeof __svelte_render<T>>>["exports"]>;
 __svelte_generic: true;
 element?: typeof HTMLElement;
 z_$$bindings?: any;
 };
+type __SvelteComponent_Select_<T extends { id: string; label: string }> = ReturnType<typeof __SvelteComponent_Select_<T>>;
 export default __SvelteComponent_Select_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__host_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__host_rune.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -175,6 +180,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__inspect_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__inspect_rune.snap
@@ -21,6 +21,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -29,7 +34,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -180,6 +185,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__javascript_component.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__javascript_component.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -181,6 +186,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Simple_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Simple_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Simple_: __SvelteComponent<__SvelteProps_Simple_, __SvelteExports_Simple_>;
+type __SvelteComponent_Simple_ = ReturnType<typeof __SvelteComponent_Simple_>;
 export default __SvelteComponent_Simple_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__layout_children.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__layout_children.snap
@@ -27,6 +27,11 @@ import type { LayoutProps } from './$types';
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -35,7 +40,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -192,6 +197,7 @@ return { props: null as any as { children: unknown }, exports: {}, slots: {}, ev
 type __SvelteProps_Layout_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Layout_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Layout_: __SvelteComponent<__SvelteProps_Layout_, __SvelteExports_Layout_>;
+type __SvelteComponent_Layout_ = ReturnType<typeof __SvelteComponent_Layout_>;
 export default __SvelteComponent_Layout_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__module_script.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__module_script.snap
@@ -27,6 +27,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -35,7 +40,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -192,6 +197,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_components_deep.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_components_deep.snap
@@ -30,6 +30,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -38,7 +43,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -212,6 +217,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_expressions.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_expressions.snap
@@ -24,6 +24,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -32,7 +37,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -188,6 +193,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_template_literal_complex.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_template_literal_complex.snap
@@ -26,6 +26,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -34,7 +39,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -190,6 +195,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_template_literal_in_expression.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_template_literal_in_expression.snap
@@ -24,6 +24,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -32,7 +37,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -186,6 +191,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__nested_template_literal_multiple_levels.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__nested_template_literal_multiple_levels.snap
@@ -21,6 +21,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -29,7 +34,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -181,6 +186,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__only_template.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__only_template.snap
@@ -16,6 +16,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -24,7 +29,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -163,6 +168,7 @@ declare module "svelte" {
 // === COMPONENT TYPE EXPORT ===
 type __SvelteProps_Test_ = __SvelteLoosen<{}>;
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_comment_before.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_comment_before.snap
@@ -23,6 +23,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -31,7 +36,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -184,6 +189,7 @@ return { props: null as any as { children: unknown }, exports: {}, slots: {}, ev
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_generic.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_generic.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -179,6 +184,7 @@ return { props: null as any as __SvelteOptionalProps<{ name: string; greeting?: 
 type __SvelteProps_Greeting_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Greeting_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Greeting_: __SvelteComponent<__SvelteProps_Greeting_, __SvelteExports_Greeting_>;
+type __SvelteComponent_Greeting_ = ReturnType<typeof __SvelteComponent_Greeting_>;
 export default __SvelteComponent_Greeting_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_prior_function_return_type.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_prior_function_return_type.snap
@@ -24,6 +24,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -32,7 +37,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -186,6 +191,7 @@ return { props: null as any as { role?: string }, exports: {}, slots: {}, events
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_prior_typed_const.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_prior_typed_const.snap
@@ -21,6 +21,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -29,7 +34,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -180,6 +185,7 @@ return { props: null as any as { label?: string }, exports: {}, slots: {}, event
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_rest.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_rest.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -181,6 +186,7 @@ return { props: null as any as { class?: string } & Record<string, unknown>, exp
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_rest_loosened_annotation.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_rest_loosened_annotation.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -183,6 +188,7 @@ return { props: null as any as Foo & Bar<{ baz: string }>, exports: {}, slots: {
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_rune.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -179,6 +184,7 @@ return { props: null as any as __SvelteOptionalProps<{ name: string; count?: num
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_template_literal_defaults.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_template_literal_defaults.snap
@@ -24,6 +24,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -32,7 +37,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -191,6 +196,7 @@ return { props: null as any as __SvelteOptionalProps<{
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_type_annotation.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_type_annotation.snap
@@ -21,6 +21,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -29,7 +34,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -183,6 +188,7 @@ return { props: null as any as Props, exports: {}, slots: {}, events: {} };
 type __SvelteProps_Counter_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Counter_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Counter_: __SvelteComponent<__SvelteProps_Counter_, __SvelteExports_Counter_>;
+type __SvelteComponent_Counter_ = ReturnType<typeof __SvelteComponent_Counter_>;
 export default __SvelteComponent_Counter_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__props_untyped_class_rename.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__props_untyped_class_rename.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -183,6 +188,7 @@ return { props: null as any as { children: unknown; class?: string }, exports: {
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__rewrite_external_imports.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__rewrite_external_imports.snap
@@ -37,6 +37,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -45,7 +50,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -213,6 +218,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Input_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Input_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Input_: __SvelteComponent<__SvelteProps_Input_, __SvelteExports_Input_>;
+type __SvelteComponent_Input_ = ReturnType<typeof __SvelteComponent_Input_>;
 export default __SvelteComponent_Input_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__rewrite_external_imports_side_effect.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__rewrite_external_imports_side_effect.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -184,6 +189,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Input_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Input_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Input_: __SvelteComponent<__SvelteProps_Input_, __SvelteExports_Input_>;
+type __SvelteComponent_Input_ = ReturnType<typeof __SvelteComponent_Input_>;
 export default __SvelteComponent_Input_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_array_destructure_trailing_comma.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_array_destructure_trailing_comma.snap
@@ -26,6 +26,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -34,7 +39,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -190,6 +195,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_component_prop_trailing_comma.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_component_prop_trailing_comma.snap
@@ -31,6 +31,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -39,7 +44,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -203,6 +208,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_store_typeof.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_store_typeof.snap
@@ -25,6 +25,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -33,7 +38,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -190,6 +195,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_typed_destructure_multiline_trailing_comma.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_typed_destructure_multiline_trailing_comma.snap
@@ -40,6 +40,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -48,7 +53,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -222,6 +227,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_typed_destructure_trailing_comma.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_typed_destructure_trailing_comma.snap
@@ -29,6 +29,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -37,7 +42,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -196,6 +201,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__snippet_with_const_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__snippet_with_const_transform.snap
@@ -29,6 +29,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -37,7 +42,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -196,6 +201,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__special_chars.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__special_chars.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -178,6 +183,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__spread_rest_props.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__spread_rest_props.snap
@@ -27,6 +27,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -35,7 +40,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -201,6 +206,7 @@ return { props: null as any as __SvelteOptionalProps<{
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__state_raw_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__state_raw_rune.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -178,6 +183,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__state_rune.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__state_rune.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -183,6 +188,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__store_in_script_function.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__store_in_script_function.snap
@@ -25,6 +25,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -33,7 +38,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -192,6 +197,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_css_custom_property.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_css_custom_property.snap
@@ -24,6 +24,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -32,7 +37,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -188,16 +193,17 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 
 === Source Map Mappings (9) ===
-  0: generated 6643..6665 -> original 18..40
-  1: generated 6665..6674 -> original 40..49
-  2: generated 6674..6692 -> original 49..67
-  3: generated 6692..6706 -> original 67..81
-  4: generated 6706..6708 -> original 81..83
-  5: generated 6743..6786 -> original 124..167
-  6: generated 6832..6833 -> original 180..181
-  7: generated 6847..6852 -> original 214..219
-  8: generated 6856..6861 -> original 238..241
+  0: generated 6840..6862 -> original 18..40
+  1: generated 6862..6871 -> original 40..49
+  2: generated 6871..6889 -> original 49..67
+  3: generated 6889..6903 -> original 67..81
+  4: generated 6903..6905 -> original 81..83
+  5: generated 6940..6983 -> original 124..167
+  6: generated 7029..7030 -> original 180..181
+  7: generated 7044..7049 -> original 214..219
+  8: generated 7053..7058 -> original 238..241

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_expression.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_expression.snap
@@ -21,6 +21,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -29,7 +34,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -181,6 +186,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_important.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_important.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -179,6 +184,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_multiple.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_multiple.snap
@@ -28,6 +28,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -36,7 +41,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -190,6 +195,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_shorthand.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_shorthand.snap
@@ -21,6 +21,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -29,7 +34,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -181,6 +186,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_string.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_string.snap
@@ -16,6 +16,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -24,7 +29,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -170,6 +175,7 @@ async function __svelte_template_check__() {
 // === COMPONENT TYPE EXPORT ===
 type __SvelteProps_Test_ = __SvelteLoosen<{}>;
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_with_attr.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_directive_with_attr.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -182,6 +187,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__style_shorthand_element.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__style_shorthand_element.snap
@@ -20,6 +20,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -28,7 +33,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -178,6 +183,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__sveltekit_page_no_props.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__sveltekit_page_no_props.snap
@@ -23,6 +23,11 @@ import type { PageProps } from './$types';
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -31,7 +36,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -185,6 +190,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Page_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Page_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Page_: __SvelteComponent<__SvelteProps_Page_, __SvelteExports_Page_>;
+type __SvelteComponent_Page_ = ReturnType<typeof __SvelteComponent_Page_>;
 export default __SvelteComponent_Page_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__sveltekit_page_with_props.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__sveltekit_page_with_props.snap
@@ -21,6 +21,11 @@ import type { PageProps } from './$types';
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -29,7 +34,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -179,6 +184,7 @@ return { props: null as any as { data: unknown }, exports: {}, slots: {}, events
 type __SvelteProps_Page_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Page_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Page_: __SvelteComponent<__SvelteProps_Page_, __SvelteExports_Page_>;
+type __SvelteComponent_Page_ = ReturnType<typeof __SvelteComponent_Page_>;
 export default __SvelteComponent_Page_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_await_block.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_await_block.snap
@@ -26,6 +26,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -34,7 +39,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -200,6 +205,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_await_block_typed.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_await_block_typed.snap
@@ -33,6 +33,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -41,7 +46,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -225,6 +230,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_each_block.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_each_block.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -185,6 +190,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_each_else.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_each_else.snap
@@ -24,6 +24,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -32,7 +37,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -187,6 +192,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_expression.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_expression.snap
@@ -21,6 +21,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -29,7 +34,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -180,6 +185,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_if_block.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_if_block.snap
@@ -27,6 +27,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -35,7 +40,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -190,6 +195,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_if_else.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_if_else.snap
@@ -26,6 +26,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -34,7 +39,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -187,6 +192,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_snippet.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_snippet.snap
@@ -28,6 +28,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -36,7 +41,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -193,6 +198,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__template_snippet_generic_header.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__template_snippet_generic_header.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -181,6 +186,7 @@ async function __svelte_template_check__() {
 // === COMPONENT TYPE EXPORT ===
 type __SvelteProps_Test_ = __SvelteLoosen<{}>;
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__ts_ignore_in_tag.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__ts_ignore_in_tag.snap
@@ -68,6 +68,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -76,7 +81,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -279,6 +284,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_basic.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_basic.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -182,6 +187,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_deep_member_access.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_deep_member_access.snap
@@ -28,6 +28,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -36,7 +41,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -194,6 +199,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access.snap
@@ -26,6 +26,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -34,7 +39,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -195,6 +200,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access_with_parameter.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_member_access_with_parameter.snap
@@ -27,6 +27,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -35,7 +40,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -192,6 +197,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_multiple_with_member_access.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_multiple_with_member_access.snap
@@ -28,6 +28,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -36,7 +41,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -196,6 +201,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_source_mapping.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_source_mapping.snap
@@ -26,6 +26,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -34,7 +39,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -188,9 +193,10 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 
 === Source Map Mappings (2) ===
-  0: generated 6643..6763 -> original 18..138
-  1: generated 6846..6858 -> original 159..171
+  0: generated 6840..6960 -> original 18..138
+  1: generated 7043..7055 -> original 159..171

--- a/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_with_parameter.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__use_directive_with_parameter.snap
@@ -23,6 +23,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -31,7 +36,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -184,6 +189,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__xlink_href_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__xlink_href_transform.snap
@@ -18,6 +18,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -26,7 +31,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -176,6 +181,7 @@ async function __svelte_template_check__() {
 // === COMPONENT TYPE EXPORT ===
 type __SvelteProps_Test_ = __SvelteLoosen<{}>;
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/svelte-transformer/tests/snapshots/snapshots__xmlns_xlink_transform.snap
+++ b/crates/svelte-transformer/tests/snapshots/snapshots__xmlns_xlink_transform.snap
@@ -22,6 +22,11 @@ import type { SvelteHTMLElements as __SvelteHTMLElements, HTMLAttributes as __Sv
 // Helper functions for template type-checking
 type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+type __SvelteComponentInstance<
+  Props extends Record<string, any>,
+  Exports extends Record<string, any>
+> = ReturnType<__SvelteComponentType<Props, Exports>>;
+
 // Isomorphic component type that supports both constructor (new) and call signatures
 interface __SvelteComponent<
   Props extends Record<string, any> = {},
@@ -30,7 +35,7 @@ interface __SvelteComponent<
   // Constructor signature for `new Component({ target, props })`
   new (options: { target: any; props?: Props & __SvelteCssProps }): __SvelteLegacyComponent<Props, any, any> & Exports;
   // Call signature for Svelte 5 function components
-  (internal: unknown, props: Props & __SvelteCssProps): Exports;
+  (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
 }
 
 // Normalize legacy class components to a callable form.
@@ -188,6 +193,7 @@ return { props: null as any as Record<string, unknown>, exports: {}, slots: {}, 
 type __SvelteProps_Test_ = Awaited<ReturnType<typeof __svelte_render>>["props"];
 type __SvelteExports_Test_ = Awaited<ReturnType<typeof __svelte_render>>["exports"];
 declare const __SvelteComponent_Test_: __SvelteComponent<__SvelteProps_Test_, __SvelteExports_Test_>;
+type __SvelteComponent_Test_ = ReturnType<typeof __SvelteComponent_Test_>;
 export default __SvelteComponent_Test_;
 
 

--- a/crates/tsgo-runner/src/runner.rs
+++ b/crates/tsgo-runner/src/runner.rs
@@ -26,6 +26,11 @@ export {};
 declare global {
   type __SvelteCssProps = { [K in `--${string}`]?: string | number };
 
+  type __SvelteComponentInstance<
+    Props extends Record<string, any>,
+    Exports extends Record<string, any>
+  > = ReturnType<SvelteComponentType<Props, Exports>>;
+
   // Isomorphic component type that supports both constructor (new) and call signatures
   // This allows usage with both class components and Svelte 5 function components
   interface __SvelteComponent<
@@ -35,7 +40,7 @@ declare global {
     // Constructor signature for `new Component({ target, props })`
     new (options: { target: any; props?: Props & __SvelteCssProps }): SvelteLegacyComponent<Props, any, any> & Exports;
     // Call signature for Svelte 5 function components
-    (internal: unknown, props: Props & __SvelteCssProps): Exports;
+    (internal: unknown, props: Props & __SvelteCssProps): __SvelteComponentInstance<Props, Exports>;
   }
 
   // Normalize legacy class components to a callable form.

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/+page.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+    import type DirectTarget from "./components/Target.svelte";
+    import type LegacyTarget from "./components/LegacyTarget.svelte";
+    import JavaScriptTarget from "./components/JavaScriptTarget.svelte";
+    import { GenericTarget, ScriptlessTarget, Target } from "./index";
+
+    type Equal<Left, Right> =
+        (<Value>() => Value extends Left ? 1 : 2) extends
+        (<Value>() => Value extends Right ? 1 : 2)
+            ? true
+            : false;
+    type Assert<Condition extends true> = Condition;
+    type IsAny<Value> = 0 extends 1 & Value ? true : false;
+
+    interface Item {
+        id: string;
+        count: number;
+    }
+
+    const item: Item = { id: "one", count: 1 };
+
+    let target = $state<Target>();
+    let genericTarget = $state<GenericTarget<Item>>();
+    let javaScriptTarget = $state<JavaScriptTarget>();
+    let scriptlessTarget = $state<ScriptlessTarget>();
+
+    type _BarrelPreservesInstanceType = Assert<Equal<IsAny<Target>, false>>;
+    type _DirectTypeImportMatchesBarrel = Assert<Equal<DirectTarget, Target>>;
+    type _MethodReturnIsPrecise = Assert<Equal<ReturnType<Target["readLabel"]>, string>>;
+    type _LegacySetPropsArePrecise = Assert<
+        Equal<Parameters<NonNullable<Target["$set"]>>[0], { label?: string }>
+    >;
+    type _LegacyOnUnsubscribes = Assert<
+        Equal<ReturnType<NonNullable<Target["$on"]>>, () => void>
+    >;
+    type _GenericReturnIsPrecise = Assert<
+        Equal<ReturnType<GenericTarget<Item>["current"]>, Item>
+    >;
+    type _GenericSetPropsArePrecise = Assert<
+        Equal<Parameters<NonNullable<GenericTarget<Item>["$set"]>>[0], { item?: Item }>
+    >;
+    type _GenericDefaultIsPreserved = Assert<
+        Equal<ReturnType<GenericTarget["current"]>, Item>
+    >;
+    type _JavaScriptReturnIsPrecise = Assert<
+        Equal<ReturnType<JavaScriptTarget["reset"]>, number>
+    >;
+    type _ScriptlessInstanceIsNotAny = Assert<Equal<IsAny<ScriptlessTarget>, false>>;
+    type _LegacyInstanceIsNotAny = Assert<Equal<IsAny<LegacyTarget>, false>>;
+
+    // @ts-expect-error generic constraints must survive the merged type export
+    type _InvalidGenericArgument = GenericTarget<{ name: string }>;
+
+    // @ts-expect-error only actual component exports belong to the instance type
+    type _MissingMethod = Target["missing"];
+
+</script>
+
+<Target label="ready" bind:this={target} />
+<GenericTarget {item} bind:this={genericTarget} />
+<JavaScriptTarget bind:this={javaScriptTarget} />
+<ScriptlessTarget bind:this={scriptlessTarget} />
+
+<button onclick={() => target?.readLabel()}>Read</button>
+<button onclick={() => genericTarget?.current()}>Current</button>
+<button onclick={() => javaScriptTarget?.reset()}>Reset</button>

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/components/GenericTarget.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/components/GenericTarget.svelte
@@ -1,0 +1,9 @@
+<script lang="ts" generics="const T extends { id: string } = { id: string; count: number }">
+    let { item }: { item: T } = $props();
+
+    export function current(): T {
+        return item;
+    }
+</script>
+
+<span>{item.id}</span>

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/components/JavaScriptTarget.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/components/JavaScriptTarget.svelte
@@ -1,0 +1,7 @@
+<script>
+    export function reset() {
+        return 0;
+    }
+</script>
+
+<button>Reset</button>

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/components/LegacyTarget.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/components/LegacyTarget.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+    export let value: string = "";
+</script>
+
+<span>{value}</span>

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/components/ScriptlessTarget.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/components/ScriptlessTarget.svelte
@@ -1,0 +1,1 @@
+<div>Scriptless</div>

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/components/Target.svelte
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/components/Target.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+    let { label }: { label: string } = $props();
+
+    export function readLabel(): string {
+        return label;
+    }
+</script>
+
+<button>{label}</button>

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/components/index.ts
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/components/index.ts
@@ -1,0 +1,5 @@
+import GenericTarget from "./GenericTarget.svelte";
+import ScriptlessTarget from "./ScriptlessTarget.svelte";
+import Target from "./Target.svelte";
+
+export { GenericTarget, ScriptlessTarget, Target };

--- a/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/index.ts
+++ b/test-fixtures/projects/sveltekit-bundler/src/routes/component-instance-types/index.ts
@@ -1,0 +1,1 @@
+export * from "./components";


### PR DESCRIPTION
## Summary

AI generated. Model: GPT 5.6 Sol Ultra.

- Make imported Svelte components usable as instance types as well as runtime values.
- Model the instance type from Svelte's own component return type so exported members, `$on`, and `$set` remain precise.
- Support ordinary, generic, JavaScript, scriptless, and legacy components, including components imported through barrel files.

## Problem

TypeScript has separate value and type namespaces. A generated component currently occupies only the value namespace, which is enough to render or mount it but not enough to use the import as an instance type:

```svelte
<script lang="ts">
  import Modal from './Modal.svelte';

  let modal = $state<Modal>();
</script>
```

This produced TS2749: `Modal refers to a value, but is being used as a type here`. The same problem affects explicit type annotations, type-only imports, named barrel re-exports, and other code that stores or passes component instances.

The generated module now declares a same-name type alongside the component value. Because TypeScript permits a value and a type to share an identifier, a default import exposes both sides under the component's normal name, matching the behavior of `svelte2tsx`.

## Implementation

- Emit `type Component = ReturnType<typeof Component>` next to each generated component value. The alias describes an instance; it does not change the component's callable value type.
- Derive component instances from Svelte's `Component<Props, Exports>` return type instead of recreating that shape locally. This preserves precise component exports and Svelte's optional `$on`/`$set` compatibility methods, including the correct prop type for `$set`.
- Generate the equivalent parameterized alias for generic components while retaining constraints, defaults, references between parameters, and `const` inference modifiers.
- Remove `const` only from the generated type-alias parameter list because TypeScript permits it on function type parameters but rejects it on type aliases with TS1277.
- Treat legacy `export let` and `export var` declarations as props rather than instance exports. Actual component exports—such as exported constants, functions, classes, and named export lists—remain available on the instance type.

## Compatibility

This only changes the virtual TypeScript declarations used for checking; it has no effect on compiled component output or runtime behavior.

The implementation follows this repository's Svelte 5+ support policy and uses the callable Svelte 5 component model. It intentionally does not implement the Svelte 4 constructor compatibility path retained by language-tools.

Regression coverage includes:

- direct default imports and type-only imports
- named re-exports through multiple barrel files
- precise exported members and rejection of nonexistent members
- `$state<Component>()`, explicit type annotations, and `bind:this`
- generic constraints, defaults, dependent parameters, and `const` parameters
- precise `$set` behavior for ordinary and generic components
- JavaScript, scriptless, and legacy components

## Testing

- `cargo check --all-targets`
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- The original `svelte-check` reports no diagnostics for the same integration cases.
- Cold and cached checks against an existing Svelte project removed all targeted TS2749 component-instance diagnostics while leaving unrelated diagnostics unchanged.

Cross-platform tests were not run locally; repository CI covers Ubuntu, macOS, and Windows.
